### PR TITLE
fix: brainstorm column doesn't scroll horizontally with rest of page (#POT-11)

### DIFF
--- a/apps/frontend/src/components/board/Board.test.tsx
+++ b/apps/frontend/src/components/board/Board.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { Board } from './Board'
+
+// Mock all external dependencies
+vi.mock('@/hooks/queries', () => ({
+  useTickets: () => ({ data: [], isLoading: false, error: null }),
+  useProjectPhases: () => ({ data: ['Ideas', 'Build', 'Done'] }),
+  useTemplate: () => ({ data: { phases: [] } }),
+  useProjects: () => ({
+    data: [{ id: 'test-project', template: { name: 'product-development' } }]
+  }),
+  useUpdateTicket: () => ({ mutate: vi.fn() }),
+  useToggleDisabledPhase: () => ({ mutate: vi.fn() }),
+  useUpdateProject: () => ({ mutate: vi.fn() })
+}))
+
+vi.mock('@/stores/appStore', () => ({
+  useAppStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      boardViewMode: 'kanban',
+      openAddTicketModal: vi.fn(),
+      showArchivedTickets: false
+    })
+}))
+
+vi.mock('@/components/TemplateUpgradeBanner', () => ({
+  TemplateUpgradeBanner: () => null
+}))
+
+vi.mock('./ArchivedSwimlane', () => ({
+  ArchivedSwimlane: () => null
+}))
+
+vi.mock('./BoardColumn', () => ({
+  BoardColumn: ({ phase }: { phase: string }) => (
+    <div data-testid={`board-column-${phase}`}>{phase}</div>
+  )
+}))
+
+vi.mock('./BrainstormColumn', () => ({
+  BrainstormColumn: () => (
+    <div data-testid="brainstorm-column">Brainstorm</div>
+  )
+}))
+
+vi.mock('./TicketCard', () => ({
+  TicketCard: () => null
+}))
+
+vi.mock('./ViewToggle', () => ({
+  ViewToggle: () => null
+}))
+
+vi.mock('./TableView', () => ({
+  TableView: () => null
+}))
+
+// Mock window.matchMedia (needed for Radix UI components)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+})
+
+describe('Board - Kanban view brainstorm column', () => {
+  it('does not apply sticky positioning classes to the brainstorm column wrapper', () => {
+    const { getByTestId } = render(<Board projectId="test-project" />)
+
+    const brainstormEl = getByTestId('brainstorm-column')
+    const wrapper = brainstormEl.parentElement!
+
+    // The wrapper should NOT have any sticky-related classes
+    expect(wrapper.className).not.toMatch(/sticky/)
+    expect(wrapper.className).not.toMatch(/sm:left-4/)
+    expect(wrapper.className).not.toMatch(/sm:z-10/)
+    expect(wrapper.className).not.toMatch(/sm:bg-bg-primary/)
+    expect(wrapper.className).not.toMatch(/sm:pr-4/)
+
+    // The wrapper should still have shrink-0
+    expect(wrapper.className).toMatch(/shrink-0/)
+  })
+})

--- a/apps/frontend/src/components/board/Board.tsx
+++ b/apps/frontend/src/components/board/Board.tsx
@@ -301,8 +301,8 @@ export function Board({ projectId }: BoardProps) {
           <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
             <div className="h-full overflow-x-auto overflow-y-hidden p-4">
               <div className="flex gap-4 h-full">
-                {/* Brainstorm column: scrolls on mobile, sticky on desktop */}
-                <div className="shrink-0 sm:sticky sm:left-4 sm:z-10 sm:bg-bg-primary sm:pr-4">
+                {/* Brainstorm column */}
+                <div className="shrink-0">
                   <BrainstormColumn projectId={projectId} />
                 </div>
 


### PR DESCRIPTION
## Summary

The brainstorm column in the Kanban board view used `position: sticky` on desktop (sm+ breakpoint), pinning it to the left edge while phase columns scrolled horizontally. This created a disorienting experience where the brainstorm column appeared "stuck" and didn't move with the rest of the page. This fix removes the sticky positioning so the brainstorm column scrolls naturally with all other columns.

## Changes

- `apps/frontend/src/components/board/Board.tsx` — Removed `sm:sticky sm:left-4 sm:z-10 sm:bg-bg-primary sm:pr-4` classes from brainstorm column wrapper div; updated associated comment
- `apps/frontend/src/components/board/Board.test.tsx` — New test file asserting the brainstorm column wrapper does not have sticky positioning classes

## Testing

- All tests passing (29 tests across 5 test files)
- New test verifies brainstorm column wrapper lacks sticky classes and retains `shrink-0`

## Documentation

- [Refinement](refinement.md) — Requirements for removing sticky brainstorm column
- [Architecture](architecture.md) — CSS-only fix analysis with class-by-class removal rationale
- [Specification](specification.md) — TDD implementation plan with failing test → fix → verify

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)