### PR TITLE
feat: move Add Ticket button to Ideas column header (#POT-13)

### DIFF
--- a/apps/frontend/src/components/board/Board.test.tsx
+++ b/apps/frontend/src/components/board/Board.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Board } from './Board'
+
+// Mock all external dependencies
+vi.mock('@/hooks/queries', () => ({
+  useTickets: () => ({ data: [], isLoading: false, error: null }),
+  useProjectPhases: () => ({ data: ['Ideas', 'Build', 'Done'] }),
+  useTemplate: () => ({ data: { phases: [] } }),
+  useProjects: () => ({
+    data: [{ id: 'test-project', template: { name: 'product-development' } }]
+  }),
+  useUpdateTicket: () => ({ mutate: vi.fn() }),
+  useToggleDisabledPhase: () => ({ mutate: vi.fn() }),
+  useUpdateProject: () => ({ mutate: vi.fn() })
+}))
+
+vi.mock('@/stores/appStore', () => ({
+  useAppStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      boardViewMode: 'kanban',
+      openAddTicketModal: vi.fn(),
+      showArchivedTickets: false
+    })
+}))
+
+vi.mock('@/components/TemplateUpgradeBanner', () => ({
+  TemplateUpgradeBanner: () => null
+}))
+
+vi.mock('./ArchivedSwimlane', () => ({
+  ArchivedSwimlane: () => null
+}))
+
+vi.mock('./BoardColumn', () => ({
+  BoardColumn: ({ phase, showAddTicket }: { phase: string; showAddTicket?: boolean }) => (
+    <div data-testid={`board-column-${phase}`} data-show-add-ticket={String(!!showAddTicket)}>
+      {phase}
+    </div>
+  )
+}))
+
+vi.mock('./BrainstormColumn', () => ({
+  BrainstormColumn: () => (
+    <div data-testid="brainstorm-column">Brainstorm</div>
+  )
+}))
+
+vi.mock('./TicketCard', () => ({
+  TicketCard: () => null
+}))
+
+vi.mock('./ViewToggle', () => ({
+  ViewToggle: () => <div data-testid="view-toggle">ViewToggle</div>
+}))
+
+vi.mock('./TableView', () => ({
+  TableView: () => null
+}))
+
+// Mock window.matchMedia (needed for Radix UI components)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+})
+
+describe('Board - Add Ticket button placement', () => {
+  it('does not render an Add Ticket button in the board header', () => {
+    render(<Board projectId="test-project" />)
+
+    // The board header should NOT contain an "Add Ticket" button
+    const addTicketButton = screen.queryByRole('button', { name: /add ticket/i })
+    expect(addTicketButton).toBeFalsy()
+  })
+
+  it('passes showAddTicket=true to the Ideas (first phase) column', () => {
+    render(<Board projectId="test-project" />)
+
+    // Find the Ideas column in the kanban view (the one with data-testid in the flex container)
+    const ideasColumns = screen.getAllByTestId('board-column-Ideas')
+    // There may be multiple due to different view modes - check the kanban view one
+    const kanbanIdeasColumn = ideasColumns.find(col => col.dataset.showAddTicket !== undefined)
+
+    expect(kanbanIdeasColumn?.dataset.showAddTicket).toBe('true')
+  })
+
+  it('passes showAddTicket=false to non-Ideas columns', () => {
+    render(<Board projectId="test-project" />)
+
+    // Find columns in kanban view
+    const buildColumns = screen.getAllByTestId('board-column-Build')
+    const buildColumn = buildColumns.find(col => col.dataset.showAddTicket !== undefined)
+    expect(buildColumn?.dataset.showAddTicket).toBe('false')
+
+    const doneColumns = screen.getAllByTestId('board-column-Done')
+    const doneColumn = doneColumns.find(col => col.dataset.showAddTicket !== undefined)
+    expect(doneColumn?.dataset.showAddTicket).toBe('false')
+  })
+
+  it('right-aligns the board header content (justify-end)', () => {
+    const { container } = render(<Board projectId="test-project" />)
+
+    // The board header div should use justify-end (not justify-between)
+    const header = container.querySelector('.px-4.py-3')
+    expect(header?.className).toMatch(/justify-end/)
+    expect(header?.className).not.toMatch(/justify-between/)
+  })
+})

--- a/apps/frontend/src/components/board/Board.tsx
+++ b/apps/frontend/src/components/board/Board.tsx
@@ -8,7 +8,7 @@ import {
   useSensor,
   useSensors
 } from '@dnd-kit/core'
-import { AlertTriangle, Loader2, Plus } from 'lucide-react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
 import {
   useTickets,
   useProjectPhases,
@@ -99,7 +99,6 @@ export function Board({ projectId }: BoardProps) {
 
   // View mode from store
   const boardViewMode = useAppStore((s) => s.boardViewMode)
-  const openAddTicketModal = useAppStore((s) => s.openAddTicketModal)
   const showArchivedTickets = useAppStore((s) => s.showArchivedTickets)
 
   const handleToggleDisabled = useCallback(
@@ -268,16 +267,7 @@ export function Board({ projectId }: BoardProps) {
   return (
     <div className="flex-1 flex flex-col overflow-hidden h-full">
       {/* Board Header */}
-      <div className="flex items-center justify-between px-4 py-3">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={openAddTicketModal}
-          className="gap-1.5"
-        >
-          <Plus className="h-4 w-4" />
-          Add Ticket
-        </Button>
+      <div className="flex items-center justify-end px-4 py-3">
         <ViewToggle />
       </div>
 
@@ -318,7 +308,7 @@ export function Board({ projectId }: BoardProps) {
                       phase={phase}
                       tickets={ticketsByPhase[phase] || []}
                       projectId={projectId}
-                      showAddTicket={false}
+                      showAddTicket={phase === phases?.[0]}
                       isManualPhase={isManual}
                       isDisabled={isDisabled}
                       isMigrating={isMigrating}


### PR DESCRIPTION
## Summary

Move the "Add Ticket" button from the board header into the Ideas column header as a small Plus icon button. This matches the existing BrainstormColumn pattern where a Plus icon in the column header opens a creation modal, providing visual consistency across the board UI and decluttering the board header.

## Changes

```
 apps/frontend/src/components/board/Board.test.tsx | 117 +++++++++++++++++++++
 apps/frontend/src/components/board/Board.tsx      |  16 +--
 2 files changed, 120 insertions(+), 13 deletions(-)
```

- **`Board.tsx`**: Removed full-sized "Add Ticket" `<Button>` from board header, changed header layout from `justify-between` to `justify-end`, enabled `showAddTicket` prop for the first phase (Ideas) column only via `phase === phases?.[0]`. Cleaned up unused `Plus` import and `openAddTicketModal` store selector.
- **`Board.test.tsx`** (new): 4 tests verifying the Add Ticket button is absent from the board header, `showAddTicket=true` is passed only to the Ideas column, `showAddTicket=false` is passed to all other columns, and the header uses `justify-end` layout.

No changes to `BoardColumn.tsx` — it already had the full `IconButton` + `Plus` icon implementation wired up.

## Testing

- All tests passing (32 tests across 5 test files)
- 4 new tests in `Board.test.tsx` covering button placement, prop passing, and header layout

## Documentation

- [Refinement](refinement.md) - Requirements and scope
- [Architecture](architecture.md) - Technical design (two changes in Board.tsx)
- [Specification](specification.md) - TDD implementation plan with 6 tickets

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)