### PR TITLE
fix: allow build to succeed under Linux

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,6 +2,11 @@
   "name": "@potato-cannon/desktop",
   "version": "1.0.0",
   "private": true,
+  "homepage": "https://github.com/crathgeb/potato-cannon",
+  "author": {
+    "name": "Chris Rathgeb",
+    "email": "chrisrathgeb@gmail.com"
+  },
   "type": "module",
   "main": "out/main/index.js",
   "scripts": {


### PR DESCRIPTION
With missing author metadata, the Electron builder is complaining that it won't produce AppImage or DEB output under Linux. (Ironically I don't need any of that and am just running the server locally, from source code, on a headless machine -- but it's nice to rely on `pnpm build` to work.)