### PR TITLE
feat: Accurately print URLs based on listen address

### DIFF
--- a/apps/daemon/bin/potato-cannon.js
+++ b/apps/daemon/bin/potato-cannon.js
@@ -4,6 +4,7 @@ import { program } from 'commander';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { readFileSync } from 'fs';
+import { DEFAULT_PORT } from '@potato-cannon/shared';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
@@ -17,7 +18,7 @@ program
   .command('start')
   .description('Start the daemon')
   .option('-d, --daemon', 'Run in background')
-  .option('-p, --port <port>', 'Port to listen on', '8443')
+  .option('-p, --port <port>', 'Port to listen on', String(DEFAULT_PORT))
   .action(async (options) => {
     const { startServer } = await import('../dist/index.js');
     await startServer(options);

--- a/apps/daemon/src/server/server.ts
+++ b/apps/daemon/src/server/server.ts
@@ -8,6 +8,7 @@ import { lock } from "proper-lockfile";
 
 import { DEFAULT_PORT } from "@potato-cannon/shared";
 import { eventBus } from "../utils/event-bus.js";
+import { formatListenUrls } from "../utils/listen-urls.js";
 import { Logger } from "../utils/logger.js";
 import { SessionService } from "../services/session/index.js";
 import { chatService } from "../services/chat.service.js";
@@ -612,7 +613,8 @@ export async function main(): Promise<void> {
     process.env.POTATO_DAEMON_PORT || globalConfig?.daemon?.port || DEFAULT_PORT;
   const port = typeof portValue === 'string' ? parseInt(portValue, 10) : portValue;
   server = app.listen(port, '0.0.0.0', async () => {
-    console.log(`Dashboard running at http://localhost:${port}`);
+    const urls = formatListenUrls('0.0.0.0', port);
+    console.log(`Dashboard running at:\n${urls.map((u) => `  ${u}`).join('\n')}`);
     await writePid(process.pid);
     await writeDaemonInfo({
       url: `http://localhost:${port}/mcp`,

--- a/apps/daemon/src/utils/__tests__/listen-urls.test.ts
+++ b/apps/daemon/src/utils/__tests__/listen-urls.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert";
+
+const mockNetworkInterfaces = mock.fn<typeof import("node:os").networkInterfaces>();
+const mockHostname = mock.fn<typeof import("node:os").hostname>();
+
+await mock.module("node:os", {
+  namedExports: {
+    default: {
+      networkInterfaces: mockNetworkInterfaces,
+      hostname: mockHostname,
+    },
+    networkInterfaces: mockNetworkInterfaces,
+    hostname: mockHostname,
+  },
+});
+
+const { formatListenUrls } = await import("../listen-urls.js");
+
+beforeEach(() => {
+  mockNetworkInterfaces.mock.resetCalls();
+  mockHostname.mock.resetCalls();
+});
+
+describe("formatListenUrls", () => {
+  it("returns localhost, non-internal IPv4 addresses, and hostname for 0.0.0.0", () => {
+    mockHostname.mock.mockImplementation(() => "myhost");
+    mockNetworkInterfaces.mock.mockImplementation(() => ({
+      eth0: [
+        {
+          address: "192.168.1.42",
+          netmask: "255.255.255.0",
+          family: "IPv4",
+          mac: "00:00:00:00:00:00",
+          internal: false,
+          cidr: "192.168.1.42/24",
+        },
+      ],
+    }));
+
+    const urls = formatListenUrls("0.0.0.0", 3131);
+    assert.deepStrictEqual(urls, [
+      "http://localhost:3131",
+      "http://192.168.1.42:3131",
+      "http://myhost:3131",
+    ]);
+  });
+
+  it("excludes IPv6 and internal addresses", () => {
+    mockHostname.mock.mockImplementation(() => "myhost");
+    mockNetworkInterfaces.mock.mockImplementation(() => ({
+      lo: [
+        {
+          address: "127.0.0.1",
+          netmask: "255.0.0.0",
+          family: "IPv4",
+          mac: "00:00:00:00:00:00",
+          internal: true,
+          cidr: "127.0.0.1/8",
+        },
+      ],
+      eth0: [
+        {
+          address: "fe80::1",
+          netmask: "ffff:ffff:ffff:ffff::",
+          family: "IPv6",
+          mac: "00:00:00:00:00:00",
+          internal: false,
+          cidr: "fe80::1/64",
+          scopeid: 1,
+        },
+        {
+          address: "10.0.0.5",
+          netmask: "255.255.255.0",
+          family: "IPv4",
+          mac: "00:00:00:00:00:00",
+          internal: false,
+          cidr: "10.0.0.5/24",
+        },
+      ],
+    }));
+
+    const urls = formatListenUrls("0.0.0.0", 8080);
+    assert.deepStrictEqual(urls, [
+      "http://localhost:8080",
+      "http://10.0.0.5:8080",
+      "http://myhost:8080",
+    ]);
+  });
+
+  it("does not duplicate when hostname is localhost", () => {
+    mockHostname.mock.mockImplementation(() => "localhost");
+    mockNetworkInterfaces.mock.mockImplementation(() => ({}));
+
+    const urls = formatListenUrls("0.0.0.0", 3000);
+    assert.deepStrictEqual(urls, ["http://localhost:3000"]);
+  });
+
+  it("includes addresses from multiple NICs", () => {
+    mockHostname.mock.mockImplementation(() => "server");
+    mockNetworkInterfaces.mock.mockImplementation(() => ({
+      eth0: [
+        {
+          address: "192.168.1.10",
+          netmask: "255.255.255.0",
+          family: "IPv4",
+          mac: "00:00:00:00:00:00",
+          internal: false,
+          cidr: "192.168.1.10/24",
+        },
+      ],
+      wlan0: [
+        {
+          address: "10.0.0.50",
+          netmask: "255.255.255.0",
+          family: "IPv4",
+          mac: "00:00:00:00:00:00",
+          internal: false,
+          cidr: "10.0.0.50/24",
+        },
+      ],
+    }));
+
+    const urls = formatListenUrls("0.0.0.0", 4000);
+    assert.deepStrictEqual(urls, [
+      "http://localhost:4000",
+      "http://192.168.1.10:4000",
+      "http://10.0.0.50:4000",
+      "http://server:4000",
+    ]);
+  });
+
+  it("returns only the specific address when not 0.0.0.0", () => {
+    const urls = formatListenUrls("127.0.0.1", 9090);
+    assert.deepStrictEqual(urls, ["http://127.0.0.1:9090"]);
+    assert.strictEqual(mockNetworkInterfaces.mock.callCount(), 0);
+    assert.strictEqual(mockHostname.mock.callCount(), 0);
+  });
+});

--- a/apps/daemon/src/utils/index.ts
+++ b/apps/daemon/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { eventBus } from './event-bus.js';
+export { formatListenUrls } from './listen-urls.js';
 export { Logger } from './logger.js';
 export { isValidBranchPrefix } from './validation.js';

--- a/apps/daemon/src/utils/listen-urls.ts
+++ b/apps/daemon/src/utils/listen-urls.ts
@@ -1,0 +1,30 @@
+import os from "node:os";
+
+export function formatListenUrls(
+  bindAddress: string,
+  port: number,
+): string[] {
+  if (bindAddress !== "0.0.0.0") {
+    return [`http://${bindAddress}:${port}`];
+  }
+
+  const addrs = new Set<string>();
+  addrs.add("localhost");
+
+  const interfaces = os.networkInterfaces();
+  for (const nics of Object.values(interfaces)) {
+    if (!nics) continue;
+    for (const nic of nics) {
+      if (nic.family === "IPv4" && !nic.internal) {
+        addrs.add(nic.address);
+      }
+    }
+  }
+
+  const hostname = os.hostname();
+  if (hostname) {
+    addrs.add(hostname);
+  }
+
+  return [...addrs].map((a) => `http://${a}:${port}`);
+}


### PR DESCRIPTION
# Problem Statement

The help output is confusing (it has a wrong default port) and we print `localhost` as our listen address even though we actually bind to 0.0.0.0.

# Solution

1. Use `DEFAULT_PORT` in usage info.
2. Use `os` to query network interfaces when `0.0.0.0` is the bind interface; print a line for each actual interface, and also do DNS lookup of our hostname; if it resolves, print that oto.

## Sample Output

```
Dashboard running at:
  http://localhost:3131
  http://10.180.5.200:3131
  http://raskova:3131
```
