### PR TITLE
fix: support read-only filesystem in Linux AppImage

### DIFF
--- a/apps/daemon/src/server/server.ts
+++ b/apps/daemon/src/server/server.ts
@@ -551,12 +551,16 @@ export async function main(): Promise<void> {
   // Path differs between monorepo build and Electron bundle
   let frontendDist: string | null = null;
   if (process.env.NODE_ENV !== 'development') {
-    // Try monorepo path first: apps/daemon/dist/server -> apps/frontend/dist
+    // Electron passes the frontend path explicitly via env var
+    const envPath = process.env.POTATO_FRONTEND_DIST;
+    // Try monorepo path: apps/daemon/dist/server -> apps/frontend/dist
     const monorepoPath = path.join(__dirname, '..', '..', '..', 'frontend', 'dist');
     // Electron bundle path: Resources/daemon/dist/server -> Resources/frontend
     const electronPath = path.join(__dirname, '..', '..', '..', 'frontend');
 
-    if (existsSync(path.join(monorepoPath, 'index.html'))) {
+    if (envPath && existsSync(path.join(envPath, 'index.html'))) {
+      frontendDist = envPath;
+    } else if (existsSync(path.join(monorepoPath, 'index.html'))) {
       frontendDist = monorepoPath;
     } else if (existsSync(path.join(electronPath, 'index.html'))) {
       frontendDist = electronPath;

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -37,7 +37,7 @@
     "icon": "build/icon.ico"
   },
   "linux": {
-    "target": ["AppImage", "deb"],
+    "target": ["AppImage"],
     "icon": "build/icon.png"
   }
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -25,18 +25,39 @@ async function startDaemon(): Promise<void> {
 
   // In dev: __dirname is apps/desktop/out/main/, go up 4 levels to repo root
   // In prod: daemon is bundled in resources
-  const daemonDir = isDev
+  const bundledDaemonDir = isDev
     ? path.join(__dirname, '..', '..', '..', '..', 'apps', 'daemon')
     : path.join(process.resourcesPath, 'daemon')
-  const daemonPath = path.join(daemonDir, 'bin', 'potato-cannon.js')
 
-  const nodeEnv = isDev ? 'development' : 'production'
+  // In production, _modules needs to be accessible as node_modules for ESM resolution.
+  // On Linux (AppImage), the filesystem is read-only, so we create a temp directory
+  // with symlinks. On Mac/Windows, we can symlink directly inside the bundle.
+  let daemonDir: string
+  if (!isDev && process.platform === 'linux') {
+    const tempDaemonDir = path.join(app.getPath('temp'), 'potato-cannon-daemon')
+    if (fs.existsSync(tempDaemonDir)) {
+      fs.rmSync(tempDaemonDir, { recursive: true })
+    }
+    fs.mkdirSync(tempDaemonDir, { recursive: true })
 
-  // In production, _modules needs to be symlinked to node_modules for ESM resolution
-  // (electron-builder filters out node_modules from extraResources, so we rename it during build)
-  if (!isDev) {
-    const modulesPath = path.join(daemonDir, '_modules')
-    const nodeModulesPath = path.join(daemonDir, 'node_modules')
+    for (const entry of fs.readdirSync(bundledDaemonDir)) {
+      if (entry === '_modules') continue
+      fs.symlinkSync(
+        path.join(bundledDaemonDir, entry),
+        path.join(tempDaemonDir, entry)
+      )
+    }
+
+    fs.symlinkSync(
+      path.join(bundledDaemonDir, '_modules'),
+      path.join(tempDaemonDir, 'node_modules')
+    )
+    console.log('[electron] Created temp daemon directory with node_modules symlink')
+    daemonDir = tempDaemonDir
+  } else if (!isDev) {
+    // Mac/Windows: bundle filesystem is writable, symlink directly
+    const modulesPath = path.join(bundledDaemonDir, '_modules')
+    const nodeModulesPath = path.join(bundledDaemonDir, 'node_modules')
     if (fs.existsSync(modulesPath) && !fs.existsSync(nodeModulesPath)) {
       try {
         fs.symlinkSync(modulesPath, nodeModulesPath, 'junction')
@@ -45,7 +66,13 @@ async function startDaemon(): Promise<void> {
         console.error('[electron] Failed to create node_modules symlink:', err)
       }
     }
+    daemonDir = bundledDaemonDir
+  } else {
+    daemonDir = bundledDaemonDir
   }
+
+  const daemonPath = path.join(daemonDir, 'bin', 'potato-cannon.js')
+  const nodeEnv = isDev ? 'development' : 'production'
 
   // In production, use Electron's Node.js to ensure native module compatibility
   // ELECTRON_RUN_AS_NODE makes Electron act as a regular Node.js process
@@ -54,9 +81,22 @@ async function startDaemon(): Promise<void> {
     ? { ...process.env, NODE_ENV: nodeEnv }
     : { ...process.env, NODE_ENV: nodeEnv, ELECTRON_RUN_AS_NODE: '1' }
 
+  // On Linux, pass the frontend path explicitly since the daemon runs from a
+  // temp dir where relative paths back to the AppImage won't resolve.
+  if (!isDev && process.platform === 'linux') {
+    env.POTATO_FRONTEND_DIST = path.join(process.resourcesPath, 'frontend')
+  }
+
   console.log(`[electron] Starting daemon: ${nodePath} ${daemonPath} start`)
 
-  daemonProcess = spawn(nodePath, [daemonPath, 'start'], {
+  // On Linux, use --preserve-symlinks so Node.js resolves modules relative
+  // to the symlink paths (temp dir with node_modules) rather than the real paths
+  // (read-only AppImage where only _modules exists).
+  const nodeArgs = (!isDev && process.platform === 'linux')
+    ? ['--preserve-symlinks', '--preserve-symlinks-main', daemonPath, 'start']
+    : [daemonPath, 'start']
+
+  daemonProcess = spawn(nodePath, nodeArgs, {
     env,
     stdio: ['ignore', 'pipe', 'pipe']
   })


### PR DESCRIPTION
## Summary
- Linux AppImages mount as a read-only filesystem, preventing the daemon from creating a `node_modules` symlink inside the bundle
- On Linux, creates a lightweight temp directory (`/tmp/potato-cannon-daemon/`) with symlinks to the daemon files and a proper `node_modules` → `_modules` entry, using `--preserve-symlinks` for Node.js module resolution
- Passes `POTATO_FRONTEND_DIST` env var so the daemon can locate the frontend static files from the temp dir
- Mac/Windows retain the original direct symlink approach, unchanged
- Removes `deb` from Linux build targets (AppImage only)

## Test plan
- [ ] Build and run AppImage on Linux: `pnpm build && ./apps/desktop/release/Potato\ Cannon-1.0.0.AppImage --no-sandbox`
- [ ] Verify daemon starts and frontend loads
- [ ] Verify Mac build is unaffected (`pnpm build` on macOS)
- [ ] Verify `pnpm dev:desktop` still works in development mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)