### PR TITLE
fix: wrap long suggestion answer buttons in conversation views (#POT-27)

### DIFF
--- a/apps/frontend/src/components/brainstorm/BrainstormChat.tsx
+++ b/apps/frontend/src/components/brainstorm/BrainstormChat.tsx
@@ -352,7 +352,7 @@ export function BrainstormChat({
               variant="outline"
               size="sm"
               onClick={() => handleOptionClick(option)}
-              className="text-xs"
+              className="text-xs whitespace-normal h-auto min-h-8 text-left shrink"
             >
               {option}
             </Button>

--- a/apps/frontend/src/components/ticket-detail/ActivityTab.tsx
+++ b/apps/frontend/src/components/ticket-detail/ActivityTab.tsx
@@ -286,7 +286,7 @@ export function ActivityTab({ projectId, ticketId, currentPhase: propPhase, hist
                 variant="outline"
                 size="sm"
                 onClick={() => handleOptionClick(option)}
-                className="text-xs"
+                className="text-xs whitespace-normal h-auto min-h-8 text-left shrink"
               >
                 {option}
               </Button>

--- a/apps/frontend/src/components/ticket-detail/ArtifactChat.tsx
+++ b/apps/frontend/src/components/ticket-detail/ArtifactChat.tsx
@@ -283,7 +283,7 @@ export function ArtifactChat({
               variant="outline"
               size="sm"
               onClick={() => handleOptionClick(option)}
-              className="text-xs"
+              className="text-xs whitespace-normal h-auto min-h-8 text-left shrink"
             >
               {option}
             </Button>


### PR DESCRIPTION
## Summary

Suggestion answer buttons in conversation views overflow their container when text is long, making them unreadable and unusable. This fix adds Tailwind class overrides to allow text wrapping within buttons, so long suggestions display gracefully across multiple lines while short suggestions remain compact.

## Changes

| File | Change |
|------|--------|
| `apps/frontend/src/components/ticket-detail/ActivityTab.tsx` | Add wrapping classes to suggestion Button className |
| `apps/frontend/src/components/brainstorm/BrainstormChat.tsx` | Add wrapping classes to suggestion Button className |
| `apps/frontend/src/components/ticket-detail/ArtifactChat.tsx` | Add wrapping classes to suggestion Button className |

3 files changed, 3 insertions, 3 deletions

**Classes added:** `whitespace-normal h-auto min-h-8 text-left shrink` — overrides the Button component's base `whitespace-nowrap`, `h-8`, and `shrink-0` per-instance without modifying the shared Button component.

## Testing

- All 79 frontend tests passing (3 skipped)
- No typecheck or build errors
- CSS-only change with no logic modifications

## Documentation

- [Refinement](refinement.md) — Requirements and scope
- [Architecture](architecture.md) — Root cause analysis and fix design
- [Specification](specification.md) — Implementation plan with 4 tasks

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)