### PR TITLE
feat: prevent browser autocomplete on ticket title input (#POT-26)

### DIFF
--- a/apps/frontend/src/components/board/AddTicketModal.test.tsx
+++ b/apps/frontend/src/components/board/AddTicketModal.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AddTicketModal } from './AddTicketModal'
+
+// Mock external dependencies
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+  }),
+}))
+
+vi.mock('@/stores/appStore', () => ({
+  useAppStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      currentProjectId: 'test-project',
+      addTicketModalOpen: true,
+      closeAddTicketModal: vi.fn(),
+    }),
+}))
+
+vi.mock('@/api/client', () => ({
+  api: {
+    createTicket: vi.fn(),
+  },
+}))
+
+// Mock window.matchMedia (needed for Radix UI Dialog)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+describe('AddTicketModal', () => {
+  it('renders the title input with autoComplete="off"', () => {
+    render(<AddTicketModal />)
+
+    const titleInput = screen.getByPlaceholderText('Ticket title') as HTMLInputElement
+    expect(titleInput.getAttribute('autocomplete')).toBe('off')
+  })
+})

--- a/apps/frontend/src/components/board/AddTicketModal.tsx
+++ b/apps/frontend/src/components/board/AddTicketModal.tsx
@@ -84,6 +84,7 @@ export function AddTicketModal() {
               placeholder="Ticket title"
               disabled={isSubmitting}
               autoFocus
+              autoComplete="off"
               className="bg-bg-tertiary border-border"
             />
           </div>


### PR DESCRIPTION
## Summary

When creating a new ticket via the "New Ticket" modal, the browser was displaying autocomplete suggestions (previously entered values) in the title input field. Since ticket titles are unique each time, these suggestions are unhelpful and disrupt the workflow. This adds `autoComplete="off"` to the title input to suppress browser autocomplete.

## Changes

- `apps/frontend/src/components/board/AddTicketModal.tsx` — Added `autoComplete="off"` prop to the title `<Input>` element (+1 line)
- `apps/frontend/src/components/board/AddTicketModal.test.tsx` — New test file verifying the autocomplete attribute is rendered (+49 lines)

## Testing

- All tests passing (80 passed, 3 skipped across 11 test files)
- New unit test confirms `autocomplete="off"` attribute on the title input

## Documentation

- [Refinement](refinement.md) — Requirements and scope
- [Architecture](architecture.md) — Technical design and change details
- [Specification](specification.md) — Implementation plan with TDD steps

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)