### PR TITLE
fix: enable persistent window drag region for desktop app (#POT-1)

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -835,7 +835,14 @@ button, a, [role="button"] {
 
 /* Draggable title bar - the header itself handles dragging now */
 .electron-title-bar {
-  display: none; /* Header handles drag region */
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--electron-header-height);
+  -webkit-app-region: drag;
+  z-index: 999;
+  pointer-events: none;
 }
 
 /* Header: fixed at top, spans full window width, independent of sidebar */


### PR DESCRIPTION
## Summary

The Electron desktop app's no-projects splash screen had no title bar chrome, making the window impossible to drag or reposition. This was because the custom drag region only rendered when projects existed (`hasProjects` is true), leaving the EmptyProjects screen without any draggable area.

The fix enables the existing `.electron-title-bar` div (already rendered in the root layout) as a persistent, invisible drag overlay by replacing its `display: none` CSS with fixed positioning and `-webkit-app-region: drag`. This works on all screens, future-proofing against any other views that might lack a header.

## Changes

```
 apps/frontend/src/index.css | 9 ++++++++-
 1 file changed, 8 insertions(+), 1 deletion(-)
```

- Replaced `.electron-title-bar { display: none }` with a fixed, full-width, 40px transparent overlay
- Uses `z-index: 999` (below header's `z-index: 1000`) so the header takes precedence when present
- Uses `pointer-events: none` so web click events pass through while Electron's native drag region still applies
- No JSX changes, no new files, no new dependencies — CSS-only fix

## Testing

- Frontend: 11 test files, 80 tests passed, 3 skipped
- Manual verification needed in Electron desktop app:
  - Window draggable from top 40px on EmptyProjects screen
  - macOS traffic lights work normally
  - Header drag region still works when projects are loaded
  - No visual changes to any screen

## Documentation

- [Refinement](refinement.md) — Requirements and scope
- [Architecture](architecture.md) — CSS-only design with z-index stacking explanation
- [Specification](specification.md) — Step-by-step implementation plan

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)