### PR TITLE
fix: harden daemon startup against silent crashes

### DIFF
--- a/apps/daemon/src/server/server.ts
+++ b/apps/daemon/src/server/server.ts
@@ -895,9 +895,13 @@ export async function startServer(
 
   if (options.daemon) {
     const { spawn } = await import("child_process");
+    const { openSync } = await import("fs");
+    const { homedir } = await import("os");
+    const logPath = path.join(homedir(), ".potato-cannon", "daemon.log");
+    const logFd = openSync(logPath, "a");
     const child = spawn(process.argv[0], [fileURLToPath(import.meta.url)], {
       detached: true,
-      stdio: "ignore",
+      stdio: ["ignore", logFd, logFd],
       env: { ...process.env, POTATO_DAEMON_PORT: port.toString() },
     });
     child.unref();
@@ -937,4 +941,29 @@ export async function getStatus(): Promise<{
     // Not running
   }
   return { running: false };
+}
+
+/**
+ * Auto-execute when this file is run directly.
+ * This enables daemon mode: `startServer({ daemon: true })` spawns a detached
+ * child process that runs this file (`node server.js`), which hits this guard
+ * and calls `main()`.
+ *
+ * For debugging daemon crashes, run the compiled file directly to see output
+ * in the terminal:
+ *   node apps/daemon/dist/server/server.js
+ */
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  process.on("uncaughtException", (err) => {
+    console.error("[FATAL] Uncaught exception:", err);
+    process.exit(1);
+  });
+  process.on("unhandledRejection", (err) => {
+    console.error("[FATAL] Unhandled rejection:", err);
+    process.exit(1);
+  });
+  main().catch((err) => {
+    console.error("[FATAL] main() crashed:", err);
+    process.exit(1);
+  });
 }

--- a/apps/daemon/src/stores/db.ts
+++ b/apps/daemon/src/stores/db.ts
@@ -1,8 +1,38 @@
+import { execFileSync } from "child_process";
 import Database from "better-sqlite3";
 import { DB_FILE } from "../config/paths.js";
 import { runMigrations } from "./migrations.js";
 
 let db: Database.Database | null = null;
+
+/**
+ * Verify that the better-sqlite3 native module is compatible with the current
+ * Node.js runtime. When the module was compiled against Electron's Node.js
+ * (e.g. via `electron-rebuild`), it shares the same ABI version number but has
+ * incompatible V8 internals. This causes `new Database()` to hang indefinitely
+ * rather than throwing an error, which the OS eventually kills with SIGKILL.
+ *
+ * This preflight spawns a short-lived child process to smoke-test the native
+ * module. If it hangs or crashes, we exit with a clear error message.
+ */
+function verifyNativeModule(): void {
+  try {
+    execFileSync(
+      process.execPath,
+      ["-e", "require('better-sqlite3')(':memory:').close()"],
+      { timeout: 5000, stdio: "ignore" },
+    );
+  } catch {
+    console.error(
+      "\n[FATAL] better-sqlite3 native module is incompatible with this Node.js version.\n" +
+        "This usually happens after running the Electron desktop build, which recompiles\n" +
+        "native modules against Electron's Node.js.\n\n" +
+        "Fix: pnpm rebuild better-sqlite3\n" +
+        " Or: pnpm run rebuild:node\n",
+    );
+    process.exit(1);
+  }
+}
 
 /**
  * Initialize the SQLite database.
@@ -14,6 +44,8 @@ export function initDatabase(): void {
   if (db) {
     return; // Already initialized
   }
+
+  verifyNativeModule();
 
   db = new Database(DB_FILE);
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -77,14 +77,14 @@ async function startDaemon(): Promise<void> {
   // In production, use Electron's Node.js to ensure native module compatibility
   // ELECTRON_RUN_AS_NODE makes Electron act as a regular Node.js process
   const nodePath = isDev ? process.execPath : process.execPath
-  const env = isDev
+  const env: NodeJS.ProcessEnv = isDev
     ? { ...process.env, NODE_ENV: nodeEnv }
     : { ...process.env, NODE_ENV: nodeEnv, ELECTRON_RUN_AS_NODE: '1' }
 
   // On Linux, pass the frontend path explicitly since the daemon runs from a
   // temp dir where relative paths back to the AppImage won't resolve.
   if (!isDev && process.platform === 'linux') {
-    env.POTATO_FRONTEND_DIST = path.join(process.resourcesPath, 'frontend')
+    ;(env as Record<string, string>).POTATO_FRONTEND_DIST = path.join(process.resourcesPath, 'frontend')
   }
 
   console.log(`[electron] Starting daemon: ${nodePath} ${daemonPath} start`)


### PR DESCRIPTION
## Summary

- **Daemon log redirect**: replaced `stdio: "ignore"` with redirect to `daemon.log` so daemon-mode crashes leave a trail instead of vanishing silently
- **Auto-execution guard**: added self-execution detection at the bottom of `server.ts` so the file works when spawned directly by daemon mode; includes a doc comment noting `node apps/daemon/dist/server/server.js` as a debugging technique
- **Native module preflight**: added a smoke test in `initDatabase()` that detects Electron ABI-incompatible `better-sqlite3` binaries before they hang and get SIGKILLed — exits with a clear error pointing to `pnpm rebuild better-sqlite3`
- **Desktop type fix**: minor type narrowing fix in `main.ts` env assignment

## Context

The daemon was crashing silently in `--daemon` mode. Root cause: `better-sqlite3` native module had been compiled against Electron's V8 (via `electron-rebuild`), which shares the same ABI version number but has incompatible internals. `new Database()` would hang indefinitely, eventually getting SIGKILL'd by the OS — with `stdio: "ignore"` swallowing all output.

## Test plan

- [ ] `potato-cannon start --daemon` starts successfully and `potato-cannon status` reports running
- [ ] `~/.potato-cannon/daemon.log` captures startup output when running in daemon mode
- [ ] After `pnpm run rebuild:electron`, `potato-cannon start` exits with a clear error message about native module incompatibility
- [ ] After `pnpm rebuild better-sqlite3`, daemon starts normally again
- [ ] `node apps/daemon/dist/server/server.js` runs the server directly (useful for debugging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)