### PR TITLE
feat: automate tooltips (#POT-40)

### DIFF
--- a/apps/daemon/templates/workflows/product-development/workflow.json
+++ b/apps/daemon/templates/workflows/product-development/workflow.json
@@ -7,7 +7,7 @@
     {
       "id": "Refinement",
       "name": "Refinement",
-      "description": "Refine brainstormed ideas into clear, actionable requirements",
+      "description": "AI agents refine your brainstorm into clear requirements with adversarial review",
       "workers": [
         {
           "id": "refinement-ralph-loop",
@@ -46,7 +46,7 @@
     {
       "id": "Backlog",
       "name": "Backlog",
-      "description": "Approved requirements ready for architecture design",
+      "description": "Tickets auto-advance to the next phase",
       "workers": [],
       "transitions": {
         "next": null,
@@ -56,7 +56,7 @@
     {
       "id": "Architecture",
       "name": "Architecture",
-      "description": "Design technical architecture based on refinement",
+      "description": "AI agents design technical architecture with adversarial review",
       "workers": [
         {
           "id": "architecture-ralph-loop",
@@ -89,7 +89,7 @@
     {
       "id": "Architecture Review",
       "name": "Architecture Review",
-      "description": "Human review of architecture before specification",
+      "description": "Tickets auto-advance to the next phase",
       "workers": [],
       "transitions": {
         "next": null,
@@ -99,7 +99,7 @@
     {
       "id": "Specification",
       "name": "Specification",
-      "description": "Create detailed implementation specification with wave-based tickets",
+      "description": "AI agent creates a detailed implementation specification",
       "workers": [
         {
           "id": "specification-agent",
@@ -117,7 +117,7 @@
     {
       "id": "Specification Review",
       "name": "Specification Review",
-      "description": "Human review of specification before build",
+      "description": "Tickets auto-advance to the next phase",
       "workers": [],
       "transitions": {
         "next": null,
@@ -127,7 +127,7 @@
     {
       "id": "Build",
       "name": "Build",
-      "description": "Execute specification tickets in waves with QA validation",
+      "description": "AI agents implement code from the specification with review loops",
       "workers": [
         {
           "id": "taskmaster-agent",
@@ -192,7 +192,7 @@
     {
       "id": "Pull Requests",
       "name": "Pull Requests",
-      "description": "Create pull request for completed build",
+      "description": "AI agent creates a pull request for the completed work",
       "workers": [
         {
           "id": "pr-agent",

--- a/apps/frontend/src/components/board/Board.tsx
+++ b/apps/frontend/src/components/board/Board.tsx
@@ -394,6 +394,7 @@ export function Board({ projectId }: BoardProps) {
                       onColorChange={(color) => handleSwimlaneColorChange(phase, color)}
                       wipLimit={currentProject?.wipLimits?.[phase]}
                       onWipLimitChange={(limit) => handleWipLimitChange(phase, limit)}
+                      phaseDescription={phaseConfig?.description}
                     />
                   )
                 })}

--- a/apps/frontend/src/components/board/BoardColumn.test.tsx
+++ b/apps/frontend/src/components/board/BoardColumn.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BoardColumn } from "./BoardColumn";
+
+// Mock dnd-kit
+vi.mock("@dnd-kit/core", () => ({
+  useDroppable: () => ({
+    setNodeRef: vi.fn(),
+    isOver: false,
+  }),
+}));
+
+// Mock app store
+vi.mock("@/stores/appStore", () => ({
+  useAppStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      openAddTicketModal: vi.fn(),
+    }),
+}));
+
+// Mock child components that aren't relevant to tooltip tests
+vi.mock("./TicketCard", () => ({
+  TicketCard: () => null,
+}));
+
+vi.mock("./SwimlaneBackside", () => ({
+  SwimlaneBackside: () => null,
+}));
+
+// Mock window.matchMedia (needed for Radix UI Tooltip)
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Helper to render BoardColumn with tooltip provider
+// Radix Tooltip requires pointer events; we use userEvent.setup with pointerEventsCheck disabled
+function renderBoardColumn(props: Partial<React.ComponentProps<typeof BoardColumn>> = {}) {
+  const defaultProps = {
+    phase: "Build",
+    tickets: [],
+    projectId: "test-project",
+  };
+
+  return {
+    user: userEvent.setup({ pointerEventsCheck: 0 }),
+    ...render(
+      <BoardColumn {...defaultProps} {...props} />
+    ),
+  };
+}
+
+// Helper to find the bot button (first button in the header with the bot icon)
+function getBotButton() {
+  const buttons = screen.getAllByRole("button");
+  // The bot button is typically the first button in the component
+  return buttons.find(btn => {
+    const svg = btn.querySelector('svg');
+    return svg && svg.className.baseVal.includes('lucide-bot');
+  }) || buttons[0];
+}
+
+describe("BoardColumn tooltip", () => {
+  it("shows phase description in tooltip when automated and phaseDescription is provided", async () => {
+    const { user } = renderBoardColumn({
+      canAutomate: true,
+      isAutomated: true,
+      onToggleAutomated: vi.fn(),
+      phaseDescription: "AI agents implement code from the specification with review loops",
+    });
+
+    const botButton = getBotButton();
+    await user.hover(botButton);
+
+    expect(
+      await screen.findByText("AI agents implement code from the specification with review loops")
+    ).toBeInTheDocument();
+  });
+
+  it("shows phase description in tooltip when not automated and phaseDescription is provided", async () => {
+    const { user } = renderBoardColumn({
+      canAutomate: true,
+      isAutomated: false,
+      onToggleAutomated: vi.fn(),
+      phaseDescription: "AI agents design technical architecture with adversarial review",
+    });
+
+    const botButton = getBotButton();
+    await user.hover(botButton);
+
+    expect(
+      await screen.findByText("AI agents design technical architecture with adversarial review")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to generic text when no phaseDescription is provided", async () => {
+    const { user } = renderBoardColumn({
+      canAutomate: true,
+      isAutomated: true,
+      onToggleAutomated: vi.fn(),
+    });
+
+    const botButton = getBotButton();
+    await user.hover(botButton);
+
+    expect(await screen.findByText("Automated")).toBeInTheDocument();
+  });
+
+  it("shows migration text regardless of phaseDescription", async () => {
+    const { user } = renderBoardColumn({
+      canAutomate: true,
+      isAutomated: true,
+      isMigrating: true,
+      onToggleAutomated: vi.fn(),
+      phaseDescription: "Some description",
+    });
+
+    const botButton = getBotButton();
+    await user.hover(botButton);
+
+    expect(await screen.findByText("Migration in progress...")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/board/BoardColumn.test.tsx
+++ b/apps/frontend/src/components/board/BoardColumn.test.tsx
@@ -82,9 +82,9 @@ describe("BoardColumn tooltip", () => {
     const botButton = getBotButton();
     await user.hover(botButton);
 
-    expect(
-      await screen.findByText("AI agents implement code from the specification with review loops")
-    ).toBeInTheDocument();
+    const elements = await screen.findAllByText("AI agents implement code from the specification with review loops");
+    expect(elements).toBeDefined();
+    expect(elements.length).toBeGreaterThan(0);
   });
 
   it("shows phase description in tooltip when not automated and phaseDescription is provided", async () => {
@@ -98,9 +98,9 @@ describe("BoardColumn tooltip", () => {
     const botButton = getBotButton();
     await user.hover(botButton);
 
-    expect(
-      await screen.findByText("AI agents design technical architecture with adversarial review")
-    ).toBeInTheDocument();
+    const elements = await screen.findAllByText("AI agents design technical architecture with adversarial review");
+    expect(elements).toBeDefined();
+    expect(elements.length).toBeGreaterThan(0);
   });
 
   it("falls back to generic text when no phaseDescription is provided", async () => {
@@ -113,7 +113,9 @@ describe("BoardColumn tooltip", () => {
     const botButton = getBotButton();
     await user.hover(botButton);
 
-    expect(await screen.findByText("Automated")).toBeInTheDocument();
+    const elements = await screen.findAllByText("Automated");
+    expect(elements).toBeDefined();
+    expect(elements.length).toBeGreaterThan(0);
   });
 
   it("shows migration text regardless of phaseDescription", async () => {
@@ -128,6 +130,8 @@ describe("BoardColumn tooltip", () => {
     const botButton = getBotButton();
     await user.hover(botButton);
 
-    expect(await screen.findByText("Migration in progress...")).toBeInTheDocument();
+    const elements = await screen.findAllByText("Migration in progress...");
+    expect(elements).toBeDefined();
+    expect(elements.length).toBeGreaterThan(0);
   });
 });

--- a/apps/frontend/src/components/board/BoardColumn.tsx
+++ b/apps/frontend/src/components/board/BoardColumn.tsx
@@ -26,6 +26,7 @@ interface BoardColumnProps {
   onColorChange?: (color: string | null) => void
   wipLimit?: number
   onWipLimitChange?: (limit: number | null) => void
+  phaseDescription?: string
 }
 
 export function BoardColumn({
@@ -40,7 +41,8 @@ export function BoardColumn({
   swimlaneColor,
   onColorChange,
   wipLimit,
-  onWipLimitChange
+  onWipLimitChange,
+  phaseDescription
 }: BoardColumnProps) {
   const openAddTicketModal = useAppStore((s) => s.openAddTicketModal)
   const showArchivedTickets = useAppStore((s) => s.showArchivedTickets)
@@ -57,8 +59,8 @@ export function BoardColumn({
   // Determine tooltip text
   const getTooltipText = () => {
     if (isMigrating) return 'Migration in progress...'
-    if (isAutomated) return 'Automated'
-    return 'Enable automation'
+    if (isAutomated) return phaseDescription ?? 'Automated'
+    return phaseDescription ?? 'Enable automation'
   }
 
   const handleColorChange = (color: string | null) => {

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     }
   },
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts']
   }
 })

--- a/apps/frontend/vitest.setup.ts
+++ b/apps/frontend/vitest.setup.ts
@@ -1,0 +1,17 @@
+import { cleanup } from '@testing-library/react'
+import { afterEach, vi } from 'vitest'
+
+// Polyfill ResizeObserver for jsdom
+if (!global.ResizeObserver) {
+  global.ResizeObserver = class ResizeObserver {
+    constructor(callback: ResizeObserverCallback) {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+// Auto cleanup after each test
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Summary

The automate button in board column headers now shows phase-specific descriptions when hovering, so users understand what automation runs for each phase before toggling it. Descriptions are authored in the workflow template and passed through to Radix UI tooltips. Manual checkpoint phases explain auto-advance behavior. Falls back to generic text for templates without descriptions.

## Changes

- `apps/daemon/templates/workflows/product-development/workflow.json` — Updated all 8 phase descriptions to be user-friendly tooltip text
- `apps/frontend/src/components/board/BoardColumn.tsx` — Added `phaseDescription` prop and updated `getTooltipText()` to prefer it over generic text
- `apps/frontend/src/components/board/Board.tsx` — Passes `phaseConfig.description` to `BoardColumn` as `phaseDescription` prop
- `apps/frontend/src/components/board/BoardColumn.test.tsx` — New test file with 4 tests covering description display, fallback, and migration priority

## Testing

- All tests passing (29 tests across 6 board test files)
- 4 new tests for BoardColumn tooltip behavior:
  - Shows phase description when automated
  - Shows phase description when not automated
  - Falls back to generic text when no description provided
  - Migration text takes priority over phase description

## Documentation

- [Refinement](refinement.md) — Requirements and scope
- [Architecture](architecture.md) — Data flow and component changes
- [Specification](specification.md) — Step-by-step implementation plan

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)