### PR TITLE
fix: hide 'No messages yet' when activity indicator is showing (#POT-38)

### DIFF
--- a/apps/frontend/src/components/ticket-detail/ActivityTab.test.tsx
+++ b/apps/frontend/src/components/ticket-detail/ActivityTab.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ActivityTab } from './ActivityTab'
+
+// Mock DOM APIs
+HTMLElement.prototype.scrollIntoView = vi.fn()
+
+// Mock TanStack Query
+const mockRefetchQueries = vi.fn()
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn().mockReturnValue({
+    data: [],
+    isLoading: false,
+  }),
+  useQueryClient: () => ({
+    refetchQueries: mockRefetchQueries,
+  }),
+}))
+
+// Mock SSE hooks - store callbacks so we can trigger them
+let sessionOutputCallback: ((data: Record<string, unknown>) => void) | null = null
+let ticketMessageCallback: ((data: Record<string, unknown>) => void) | null = null
+let sessionEndedCallback: ((data: Record<string, unknown>) => void) | null = null
+
+vi.mock('@/hooks/useSSE', () => ({
+  useSessionOutput: vi.fn((cb: (data: Record<string, unknown>) => void) => {
+    sessionOutputCallback = cb
+  }),
+  useTicketMessage: vi.fn((cb: (data: Record<string, unknown>) => void) => {
+    ticketMessageCallback = cb
+  }),
+  useSessionEnded: vi.fn((cb: (data: Record<string, unknown>) => void) => {
+    sessionEndedCallback = cb
+  }),
+}))
+
+// Mock API client
+vi.mock('@/api/client', () => ({
+  api: {
+    getTicketMessages: vi.fn().mockResolvedValue({ messages: [] }),
+    respondToQuestion: vi.fn(),
+  },
+}))
+
+// Mock markdown renderer
+vi.mock('@/lib/markdown', () => ({
+  renderMarkdown: vi.fn((text: string) => text),
+}))
+
+// Mock child components that aren't relevant
+vi.mock('./ArtifactViewerFull', () => ({
+  ArtifactViewerFull: () => null,
+}))
+
+vi.mock('./TaskList', () => ({
+  TaskList: () => null,
+}))
+
+vi.mock('./RestartPhaseButton', () => ({
+  RestartPhaseButton: () => null,
+}))
+
+describe('ActivityTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionOutputCallback = null
+    ticketMessageCallback = null
+    sessionEndedCallback = null
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows "No messages yet" when there are no messages and no activity', () => {
+    render(
+      <ActivityTab
+        projectId="test-project"
+        ticketId="POT-1"
+      />
+    )
+
+    const emptyStateElement = screen.getByText('No messages yet')
+    expect(emptyStateElement).toBeTruthy()
+  })
+
+  it('hides "No messages yet" when activity indicator is showing', () => {
+    render(
+      <ActivityTab
+        projectId="test-project"
+        ticketId="POT-1"
+      />
+    )
+
+    // Simulate a session output event that sets currentActivity
+    expect(sessionOutputCallback).not.toBeNull()
+    sessionOutputCallback!({
+      ticketId: 'POT-1',
+      event: {
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'read_file',
+              input: { path: 'src/index.ts' },
+            },
+          ],
+        },
+      },
+    })
+
+    // "No messages yet" should be hidden
+    const emptyStateElement = screen.queryByText('No messages yet')
+    expect(emptyStateElement).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/ticket-detail/ActivityTab.test.tsx
+++ b/apps/frontend/src/components/ticket-detail/ActivityTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
 import { ActivityTab } from './ActivityTab'
 
 // Mock DOM APIs
@@ -19,19 +19,13 @@ vi.mock('@tanstack/react-query', () => ({
 
 // Mock SSE hooks - store callbacks so we can trigger them
 let sessionOutputCallback: ((data: Record<string, unknown>) => void) | null = null
-let ticketMessageCallback: ((data: Record<string, unknown>) => void) | null = null
-let sessionEndedCallback: ((data: Record<string, unknown>) => void) | null = null
 
 vi.mock('@/hooks/useSSE', () => ({
   useSessionOutput: vi.fn((cb: (data: Record<string, unknown>) => void) => {
     sessionOutputCallback = cb
   }),
-  useTicketMessage: vi.fn((cb: (data: Record<string, unknown>) => void) => {
-    ticketMessageCallback = cb
-  }),
-  useSessionEnded: vi.fn((cb: (data: Record<string, unknown>) => void) => {
-    sessionEndedCallback = cb
-  }),
+  useTicketMessage: vi.fn(() => {}),
+  useSessionEnded: vi.fn(() => {}),
 }))
 
 // Mock API client
@@ -64,8 +58,6 @@ describe('ActivityTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sessionOutputCallback = null
-    ticketMessageCallback = null
-    sessionEndedCallback = null
   })
 
   afterEach(() => {
@@ -84,7 +76,7 @@ describe('ActivityTab', () => {
     expect(emptyStateElement).toBeTruthy()
   })
 
-  it('hides "No messages yet" when activity indicator is showing', () => {
+  it('hides "No messages yet" when activity indicator is showing', async () => {
     render(
       <ActivityTab
         projectId="test-project"
@@ -110,8 +102,10 @@ describe('ActivityTab', () => {
       },
     })
 
-    // "No messages yet" should be hidden
-    const emptyStateElement = screen.queryByText('No messages yet')
-    expect(emptyStateElement).toBeNull()
+    // "No messages yet" should be hidden after state update
+    await waitFor(() => {
+      const emptyStateElement = screen.queryByText('No messages yet')
+      expect(emptyStateElement).toBeNull()
+    })
   })
 })

--- a/apps/frontend/src/components/ticket-detail/ActivityTab.tsx
+++ b/apps/frontend/src/components/ticket-detail/ActivityTab.tsx
@@ -250,7 +250,7 @@ export function ActivityTab({ projectId, ticketId, currentPhase: propPhase, hist
                 Loading conversation...
               </div>
             )}
-            {!isLoadingHistory && messages.length === 0 && !isWaitingForResponse && (
+            {!isLoadingHistory && messages.length === 0 && !isWaitingForResponse && !currentActivity && (
               <div className="text-center py-8 text-text-muted text-sm">
                 No messages yet
               </div>


### PR DESCRIPTION
## Summary

When a new ticket phase starts, the Activity tab briefly shows both a "No messages yet" placeholder and the thinking/activity indicator simultaneously, creating an awkward visual experience. This fix hides the placeholder text whenever the activity indicator is visible, since the indicator already communicates that work is happening.

## Changes

- `apps/frontend/src/components/ticket-detail/ActivityTab.tsx` — Added `!currentActivity` condition to the empty state rendering check (line 253), so the "No messages yet" message is hidden when a Claude session is actively working
- `apps/frontend/src/components/ticket-detail/ActivityTab.test.tsx` — New test file with 2 tests verifying the empty state shows when idle and hides when activity is present
- `apps/daemon/templates/workflows/product-development/agents/taskmaster.md` — Simplified taskmaster agent by removing manual verification filtering (unrelated improvement bundled in branch)
- `apps/daemon/templates/workflows/product-development/changelog.md` — Updated changelog
- `apps/daemon/templates/workflows/product-development/workflow.json` — Version bump

## Testing

- All tests passing (2 tests in ActivityTab.test.tsx)
- Test 1: Verifies "No messages yet" shows when no messages and no activity
- Test 2: Verifies "No messages yet" hides when `currentActivity` is set via SSE event

## Documentation

- [Refinement](refinement.md) — Requirements and scope
- [Architecture](architecture.md) — Technical design (single conditional change)
- [Specification](specification.md) — Implementation plan with TDD approach

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)