### PR TITLE
fix: visual indication of selected ticket (#POT-46)

### DIFF
--- a/apps/frontend/src/components/board/TableView.test.tsx
+++ b/apps/frontend/src/components/board/TableView.test.tsx
@@ -34,6 +34,7 @@ const mockIsTicketPending = vi.fn().mockImplementation((_projectId: string, tick
   return ticketId === 'POT-1'
 })
 const mockOpenTicketSheet = vi.fn()
+let mockTicketSheetTicketId: string | null = null
 
 vi.mock('@/stores/appStore', () => ({
   useAppStore: (selector: (s: Record<string, unknown>) => unknown) => {
@@ -41,6 +42,7 @@ vi.mock('@/stores/appStore', () => ({
       openTicketSheet: mockOpenTicketSheet,
       isTicketProcessing: mockIsTicketProcessing,
       isTicketPending: mockIsTicketPending,
+      ticketSheetTicketId: mockTicketSheetTicketId,
     }
     return selector(state)
   },
@@ -85,5 +87,53 @@ describe('TableView - Pending Badge', () => {
     // Only one ? badge should exist (for POT-1)
     const badges = screen.getAllByText('?')
     expect(badges.length).toBe(1)
+  })
+})
+
+describe('TableView - Selected Row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    mockTicketSheetTicketId = null
+    cleanup()
+  })
+
+  it('should highlight the selected row with accent border', () => {
+    mockTicketSheetTicketId = 'POT-1'
+
+    const { container } = render(<TableView projectId="proj-1" />)
+
+    const rows = container.querySelectorAll('tbody tr')
+    const selectedRow = rows[0] as HTMLElement // POT-1 is first
+    const unselectedRow = rows[1] as HTMLElement // POT-2
+
+    expect(selectedRow.className).toContain('border-l-2')
+    expect(selectedRow.className).toContain('border-l-accent')
+    expect(unselectedRow.className).not.toContain('border-l-2')
+  })
+
+  it('should blend accent into row background style when selected', () => {
+    mockTicketSheetTicketId = 'POT-1'
+
+    const { container } = render(<TableView projectId="proj-1" />)
+
+    const rows = container.querySelectorAll('tbody tr')
+    const selectedRow = rows[0] as HTMLElement
+
+    expect(selectedRow.style.backgroundColor).toContain('color-mix')
+    expect(selectedRow.style.backgroundColor).toContain('var(--color-accent)')
+  })
+
+  it('should not highlight rows when no ticket is selected', () => {
+    mockTicketSheetTicketId = null
+
+    const { container } = render(<TableView projectId="proj-1" />)
+
+    const rows = container.querySelectorAll('tbody tr')
+    const row = rows[0] as HTMLElement
+
+    expect(row.className).not.toContain('border-l-2')
   })
 })

--- a/apps/frontend/src/components/board/TableView.tsx
+++ b/apps/frontend/src/components/board/TableView.tsx
@@ -107,6 +107,7 @@ export function TableView({ projectId }: TableViewProps) {
   const openTicketSheet = useAppStore((s) => s.openTicketSheet)
   const isTicketProcessingFn = useAppStore((s) => s.isTicketProcessing)
   const isTicketPendingFn = useAppStore((s) => s.isTicketPending)
+  const ticketSheetTicketId = useAppStore((s) => s.ticketSheetTicketId)
 
   // Queries
   const { data: projects } = useProjects()
@@ -287,6 +288,17 @@ export function TableView({ projectId }: TableViewProps) {
             {sortedTickets.map((ticket) => {
               const isProcessing = isTicketProcessingFn(projectId, ticket.id)
               const isPending = isTicketPendingFn(projectId, ticket.id)
+              const isRowSelected = ticketSheetTicketId === ticket.id
+
+              const rowStyle = isRowSelected
+                ? {
+                    backgroundColor: `color-mix(in srgb, var(--color-accent) 15%, ${
+                      currentProject?.swimlaneColors?.[ticket.phase]
+                        ? `color-mix(in srgb, ${currentProject.swimlaneColors[ticket.phase]} 15%, #161b22)`
+                        : 'rgba(33, 38, 45, 0.3)'
+                    })`
+                  }
+                : getRowBackgroundStyle(ticket.phase, currentProject?.swimlaneColors)
 
               return (
                 <tr
@@ -294,9 +306,10 @@ export function TableView({ projectId }: TableViewProps) {
                   onClick={() => handleRowClick(ticket.id)}
                   className={cn(
                     'hover:bg-bg-hover cursor-pointer transition-colors',
-                    isProcessing && 'bg-accent/5'
+                    isProcessing && !isRowSelected && 'bg-accent/5',
+                    isRowSelected && 'border-l-2 border-l-accent'
                   )}
-                  style={getRowBackgroundStyle(ticket.phase, currentProject?.swimlaneColors)}
+                  style={rowStyle}
                 >
                   <td className="px-4 py-3">
                     <span className="font-mono text-xs text-text-muted">

--- a/apps/frontend/src/components/board/TicketCard.test.tsx
+++ b/apps/frontend/src/components/board/TicketCard.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/stores/appStore', () => ({
       isTicketPending: mockIsTicketPending,
       isTicketArchiving: mockIsTicketArchiving,
       getTicketActivity: mockGetTicketActivity,
+      ticketSheetTicketId: 'POT-1',
     }
     return selector(state)
   },
@@ -190,5 +191,33 @@ describe('TicketCard - Pending Phase Indicator', () => {
     // The ? badge should show instead
     expect(screen.getByText('?')).toBeTruthy()
     expect(screen.queryByText('Waiting for Architecture')).toBeNull()
+  })
+})
+
+describe('TicketCard - Selected State', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('should pass isSelected to ListItemCard when ticketSheetTicketId matches', () => {
+    render(<TicketCard ticket={baseTicket as any} projectId="proj-1" />)
+
+    // The ListItemCard should receive isSelected - we verify via the rendered classes
+    // Bold selected variant applies border-accent/50 and ring-1
+    const card = screen.getByText('Test Ticket').closest('[class*="rounded-lg"]') as HTMLElement
+    expect(card.className).toContain('border-accent/50')
+    expect(card.className).toContain('ring-1')
+  })
+
+  it('should not show selected state when ticketSheetTicketId does not match', () => {
+    render(<TicketCard ticket={{ ...baseTicket, id: 'POT-99' } as any} projectId="proj-1" />)
+
+    const card = screen.getByText('Test Ticket').closest('[class*="rounded-lg"]') as HTMLElement
+    expect(card.className).not.toContain('border-accent/50')
+    expect(card.className).not.toContain('ring-1')
   })
 })

--- a/apps/frontend/src/components/board/TicketCard.tsx
+++ b/apps/frontend/src/components/board/TicketCard.tsx
@@ -28,6 +28,8 @@ export function TicketCard({ ticket, projectId, swimlaneColor }: TicketCardProps
   const activity = useAppStore((s) => s.getTicketActivity(projectId, ticket.id))
   const isPending = useAppStore((s) => s.isTicketPending(projectId, ticket.id))
   const isArchiving = useAppStore((s) => s.isTicketArchiving(projectId, ticket.id))
+  const ticketSheetTicketId = useAppStore((s) => s.ticketSheetTicketId)
+  const isSelected = ticketSheetTicketId === ticket.id
   const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false)
   const archiveTicket = useArchiveTicket()
 
@@ -90,6 +92,8 @@ export function TicketCard({ ticket, projectId, swimlaneColor }: TicketCardProps
     <ListItemCard
       asChild
       isActive={isDragging}
+      isSelected={isSelected}
+      selectedVariant="bold"
       tintColor={swimlaneColor}
     >
       <div

--- a/apps/frontend/src/components/ui/list-item-card.test.tsx
+++ b/apps/frontend/src/components/ui/list-item-card.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { ListItemCard } from './list-item-card'
+
+describe('ListItemCard', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders children', () => {
+    const { getByText } = render(<ListItemCard>Hello</ListItemCard>)
+    expect(getByText('Hello')).toBeTruthy()
+  })
+
+  it('applies default selected classes when isSelected is true and no tintColor', () => {
+    const { container } = render(<ListItemCard isSelected>Content</ListItemCard>)
+    const card = container.firstElementChild as HTMLElement
+    expect(card.className).toContain('border-accent/30')
+    expect(card.className).toContain('bg-accent/10')
+  })
+
+  it('applies bold selected classes when selectedVariant is bold and no tintColor', () => {
+    const { container } = render(
+      <ListItemCard isSelected selectedVariant="bold">Content</ListItemCard>
+    )
+    const card = container.firstElementChild as HTMLElement
+    expect(card.className).toContain('border-accent/50')
+    expect(card.className).toContain('bg-accent/15')
+    expect(card.className).toContain('ring-1')
+    expect(card.className).toContain('ring-accent/20')
+  })
+
+  it('does not apply selected classes when isSelected is false', () => {
+    const { container } = render(<ListItemCard>Content</ListItemCard>)
+    const card = container.firstElementChild as HTMLElement
+    expect(card.className).not.toContain('border-accent/30')
+    expect(card.className).not.toContain('bg-accent/50')
+  })
+
+  it('blends accent into tintColor inline style when selected with tintColor', () => {
+    const { container } = render(
+      <ListItemCard isSelected selectedVariant="bold" tintColor="#ff0000">
+        Content
+      </ListItemCard>
+    )
+    const card = container.firstElementChild as HTMLElement
+    expect(card.style.backgroundColor).toContain('color-mix')
+    expect(card.style.backgroundColor).toContain('var(--color-accent)')
+    expect(card.style.backgroundColor).toContain('#ff0000')
+  })
+
+  it('does not blend accent into tintColor inline style when not selected', () => {
+    const { container } = render(
+      <ListItemCard tintColor="#ff0000">Content</ListItemCard>
+    )
+    const card = container.firstElementChild as HTMLElement
+    expect(card.style.backgroundColor).not.toContain('var(--color-accent)')
+  })
+
+  it('applies border accent classes even when tintColor is set and selected bold', () => {
+    const { container } = render(
+      <ListItemCard isSelected selectedVariant="bold" tintColor="#ff0000">
+        Content
+      </ListItemCard>
+    )
+    const card = container.firstElementChild as HTMLElement
+    expect(card.className).toContain('border-accent/50')
+    expect(card.className).toContain('ring-1')
+    expect(card.className).toContain('ring-accent/20')
+  })
+
+  it('defaults selectedVariant to default when not specified', () => {
+    const { container } = render(<ListItemCard isSelected>Content</ListItemCard>)
+    const card = container.firstElementChild as HTMLElement
+    // Should have default classes, not bold
+    expect(card.className).toContain('border-accent/30')
+    expect(card.className).not.toContain('border-accent/50')
+    expect(card.className).not.toContain('ring-1')
+  })
+})

--- a/apps/frontend/src/components/ui/list-item-card.tsx
+++ b/apps/frontend/src/components/ui/list-item-card.tsx
@@ -10,6 +10,8 @@ interface ListItemCardProps extends React.HTMLAttributes<HTMLDivElement> {
   isActive?: boolean
   /** Tint color from parent container - card will be a lighter version */
   tintColor?: string
+  /** Selection styling intensity: 'default' for subtle, 'bold' for prominent */
+  selectedVariant?: 'default' | 'bold'
 }
 
 /**
@@ -21,6 +23,7 @@ export function ListItemCard({
   isSelected,
   isActive,
   tintColor,
+  selectedVariant = 'default',
   className,
   children,
   style,
@@ -28,13 +31,29 @@ export function ListItemCard({
 }: ListItemCardProps) {
   const Comp = asChild ? Slot : 'div'
 
-  // Create a lighter background based on the tint color
+  // Blend accent into tint when selected (fixes inline style specificity)
   const cardStyle = tintColor
     ? {
         ...style,
-        backgroundColor: `color-mix(in srgb, ${tintColor} 60%, #3a3a3c)`
+        backgroundColor: isSelected
+          ? `color-mix(in srgb, var(--color-accent) 20%, color-mix(in srgb, ${tintColor} 60%, #3a3a3c))`
+          : `color-mix(in srgb, ${tintColor} 60%, #3a3a3c)`
       }
     : style
+
+  // Selection classes (only applied when no tintColor, since tintColor uses inline style for bg)
+  const selectedClasses = isSelected && !tintColor && (
+    selectedVariant === 'bold'
+      ? 'border-accent/50 bg-accent/15 ring-1 ring-accent/20'
+      : 'border-accent/30 bg-accent/10'
+  )
+
+  // Border/ring classes always apply regardless of tintColor (no conflict with inline backgroundColor)
+  const selectedBorderClasses = isSelected && tintColor && (
+    selectedVariant === 'bold'
+      ? 'border-accent/50 ring-1 ring-accent/20'
+      : 'border-accent/30'
+  )
 
   return (
     <Comp
@@ -42,8 +61,9 @@ export function ListItemCard({
         'rounded-lg p-3 cursor-pointer transition-all',
         'border border-white/10 hover:border-white/20',
         'shadow-md shadow-black/30',
-        !tintColor && 'bg-bg-tertiary',
-        isSelected && 'border-accent/30 bg-accent/10',
+        !tintColor && !isSelected && 'bg-bg-tertiary',
+        selectedClasses,
+        selectedBorderClasses,
         isActive && 'opacity-50 shadow-lg',
         className
       )}


### PR DESCRIPTION
## Summary

When working with multiple tickets simultaneously, there was no visual indication of which ticket is currently selected in the kanban board or table view. This adds prominent selected-state highlighting to ticket cards and table rows so the active ticket is always visually clear.

## Changes

| File | Change |
|------|--------|
| `apps/frontend/src/components/ui/list-item-card.tsx` | Added `selectedVariant` prop (`'default'` \| `'bold'`) with accent-blended inline styles for tintColor specificity |
| `apps/frontend/src/components/ui/list-item-card.test.tsx` | New test suite (7 tests) for selection variant behavior |
| `apps/frontend/src/components/board/TicketCard.tsx` | Wired `ticketSheetTicketId` from appStore, passes `isSelected` + `selectedVariant="bold"` to ListItemCard |
| `apps/frontend/src/components/board/TicketCard.test.tsx` | Added 2 tests for selected/unselected card states |
| `apps/frontend/src/components/board/TableView.tsx` | Added selected row styling with accent-blended background + left border |
| `apps/frontend/src/components/board/TableView.test.tsx` | Added 3 tests for selected row highlighting |

## Testing

- All 96 tests passing (3 skipped), 12 test files
- New tests cover: ListItemCard variants, TicketCard selection, TableView row highlighting
- No existing tests broken

## Documentation

- [Refinement](refinement.md) - Requirements and success criteria
- [Architecture](architecture.md) - Component design and inline style specificity handling
- [Specification](specification.md) - TDD implementation plan with 4 tickets

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)