### PR TITLE
fix: visual indicators for selected + processing tickets (#POT-53)

### DIFF
--- a/apps/frontend/src/components/board/BrainstormCard.tsx
+++ b/apps/frontend/src/components/board/BrainstormCard.tsx
@@ -70,17 +70,15 @@ export function BrainstormCard({ brainstorm, projectId }: BrainstormCardProps) {
           <Clock className="h-3 w-3" />
           {timeAgo(brainstorm.updatedAt)}
         </span>
-        <StatusIndicator status={brainstorm.status} hasUnseenQuestion={hasUnseenQuestion} />
+        <StatusIndicator hasUnseenQuestion={hasUnseenQuestion} />
       </div>
     </button>
   )
 }
 
 function StatusIndicator({
-  status,
   hasUnseenQuestion
 }: {
-  status: Brainstorm['status']
   hasUnseenQuestion: boolean
 }) {
   if (hasUnseenQuestion) {

--- a/apps/frontend/src/components/board/TicketCard.test.tsx
+++ b/apps/frontend/src/components/board/TicketCard.test.tsx
@@ -221,3 +221,36 @@ describe('TicketCard - Selected State', () => {
     expect(card.className).not.toContain('ring-1')
   })
 })
+
+describe('TicketCard - Processing + Selected State', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('should apply both ticket-card-processing and ticket-card-selected when processing and selected', () => {
+    mockIsTicketProcessing.mockReturnValue(true)
+    mockGetTicketActivity.mockReturnValue('Building...')
+
+    // baseTicket.id is 'POT-1' which matches ticketSheetTicketId in mock store
+    render(<TicketCard ticket={baseTicket as any} projectId="proj-1" />)
+
+    const card = screen.getByText('Test Ticket').closest('[class*="rounded-lg"]') as HTMLElement
+    expect(card.className).toContain('ticket-card-processing')
+    expect(card.className).toContain('ticket-card-selected')
+  })
+
+  it('should not apply ticket-card-selected when processing but not selected', () => {
+    mockIsTicketProcessing.mockReturnValue(true)
+    mockGetTicketActivity.mockReturnValue('Building...')
+
+    render(<TicketCard ticket={{ ...baseTicket, id: 'POT-99' } as any} projectId="proj-1" />)
+
+    const card = screen.getByText('Test Ticket').closest('[class*="rounded-lg"]') as HTMLElement
+    expect(card.className).toContain('ticket-card-processing')
+    expect(card.className).not.toContain('ticket-card-selected')
+  })
+})

--- a/apps/frontend/src/components/board/TicketCard.tsx
+++ b/apps/frontend/src/components/board/TicketCard.tsx
@@ -105,6 +105,7 @@ export function TicketCard({ ticket, projectId, swimlaneColor }: TicketCardProps
         className={cn(
           'relative group',
           isProcessing && 'ticket-card-processing',
+          isProcessing && isSelected && 'ticket-card-selected',
           isArchiving && 'opacity-50 pointer-events-none cursor-not-allowed'
         )}
       >

--- a/apps/frontend/src/components/brainstorm/BrainstormListItem.tsx
+++ b/apps/frontend/src/components/brainstorm/BrainstormListItem.tsx
@@ -71,7 +71,6 @@ export function BrainstormListItem({
               {brainstorm.name}
             </span>
             <StatusIndicator
-              status={brainstorm.status}
               hasUnseenQuestion={hasUnseenQuestion}
             />
           </div>
@@ -86,10 +85,8 @@ export function BrainstormListItem({
 }
 
 function StatusIndicator({
-  status,
   hasUnseenQuestion
 }: {
-  status: Brainstorm['status']
   hasUnseenQuestion: boolean
 }) {
   // Active brainstorm with unseen pending question - show unread indicator

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -743,6 +743,11 @@ button, a, [role="button"] {
   animation: border-travel 4s linear infinite;
 }
 
+/* Selected + processing: show accent background through the animation */
+.ticket-card-processing.ticket-card-selected {
+  --processing-fill: color-mix(in srgb, var(--color-accent) 15%, var(--color-bg-tertiary));
+}
+
 @media (prefers-reduced-motion: reduce) {
   .ticket-card-processing::before {
     animation: none;
@@ -750,11 +755,6 @@ button, a, [role="button"] {
       linear-gradient(var(--processing-fill), var(--processing-fill)) padding-box,
       linear-gradient(var(--color-accent), var(--color-accent)) border-box;
   }
-}
-
-/* Selected + processing: show accent background through the animation */
-.ticket-card-processing.ticket-card-selected {
-  --processing-fill: color-mix(in srgb, var(--color-accent) 15%, var(--color-bg-tertiary));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -752,6 +752,11 @@ button, a, [role="button"] {
   }
 }
 
+/* Selected + processing: show accent background through the animation */
+.ticket-card-processing.ticket-card-selected {
+  --processing-fill: color-mix(in srgb, var(--color-accent) 15%, var(--color-bg-tertiary));
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-pending-glow {
     animation: none;

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -716,6 +716,7 @@ button, a, [role="button"] {
 
 /* Processing ticket card border animation */
 .ticket-card-processing {
+  --processing-fill: var(--color-bg-tertiary);
   position: relative;
   z-index: 0;
   background: transparent !important;
@@ -729,7 +730,7 @@ button, a, [role="button"] {
   border-radius: var(--radius-sm);
   border: 2px solid transparent;
   background:
-    linear-gradient(var(--color-bg-tertiary), var(--color-bg-tertiary)) padding-box,
+    linear-gradient(var(--processing-fill), var(--processing-fill)) padding-box,
     conic-gradient(
       from var(--border-angle),
       transparent 0deg,
@@ -746,7 +747,7 @@ button, a, [role="button"] {
   .ticket-card-processing::before {
     animation: none;
     background:
-      linear-gradient(var(--color-bg-tertiary), var(--color-bg-tertiary)) padding-box,
+      linear-gradient(var(--processing-fill), var(--processing-fill)) padding-box,
       linear-gradient(var(--color-accent), var(--color-accent)) border-box;
   }
 }


### PR DESCRIPTION
## Summary

When a kanban ticket was both selected and actively processing (agent running), the selected visual indication (accent-tinted background) was lost. The `.ticket-card-processing` CSS class used `background: transparent !important` which overrode the selected state styling. This fix introduces a `--processing-fill` CSS custom property so the `::before` pseudo-element's background fill can be overridden by a compound `.ticket-card-processing.ticket-card-selected` selector, restoring the accent-tinted background while preserving the rotating glimmer border animation.

## Changes

- `apps/frontend/src/index.css` — Added `--processing-fill` custom property to `.ticket-card-processing`, replaced hardcoded `var(--color-bg-tertiary)` with `var(--processing-fill)` in `::before` and reduced-motion variant, added compound selector for selected+processing state
- `apps/frontend/src/components/board/TicketCard.tsx` — Added `ticket-card-selected` class when ticket is both processing and selected
- `apps/frontend/src/components/board/TicketCard.test.tsx` — Added tests for processing + selected state coexistence
- `apps/frontend/src/components/board/BrainstormCard.tsx` — Removed unused `status` prop from `StatusIndicator`
- `apps/frontend/src/components/brainstorm/BrainstormListItem.tsx` — Removed unused `status` prop from `StatusIndicator`

## Testing

- All tests passing (116 tests, 3 skipped)
- New tests verify `ticket-card-selected` class is applied alongside `ticket-card-processing` when both states are active
- New tests verify `ticket-card-selected` is NOT applied when processing but not selected

## Documentation

- [Refinement](refinement.md) — Requirements and success criteria
- [Architecture](architecture.md) — CSS custom property approach with `--processing-fill`
- [Specification](specification.md) — Step-by-step implementation plan

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)