### PR TITLE
feat: custom ticket number support (#POT-52)

### DIFF
--- a/apps/daemon/src/mcp/tools/__tests__/ticket.tools.test.ts
+++ b/apps/daemon/src/mcp/tools/__tests__/ticket.tools.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { ticketTools, ticketHandlers } from "../ticket.tools.js";
+import type { McpContext, McpToolResult } from "../../../types/mcp.types.js";
+
+// Mock fetch for testing
+let mockFetchCalls: {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}[] = [];
+
+let mockFetchResponse: { ok: boolean; json: () => Promise<unknown>; statusText?: string } = {
+  ok: true,
+  json: async () => ({ id: "POT-123", title: "Test Ticket" }),
+};
+
+const originalFetch = globalThis.fetch;
+
+describe("MCP create_ticket Tool - ticketNumber Support", () => {
+  beforeEach(() => {
+    mockFetchCalls = [];
+    mockFetchResponse = {
+      ok: true,
+      json: async () => ({ id: "POT-123", title: "Test Ticket" }),
+    };
+
+    // Mock fetch globally
+    globalThis.fetch = (async (url: string, options?: RequestInit) => {
+      mockFetchCalls.push({
+        url,
+        method: options?.method,
+        headers: options?.headers as Record<string, string>,
+        body: options?.body as string,
+      });
+      return mockFetchResponse;
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("Tool Schema", () => {
+    it("should include create_ticket tool", () => {
+      const createTicketTool = ticketTools.find((t) => t.name === "create_ticket");
+      assert.ok(createTicketTool, "create_ticket tool should exist");
+    });
+
+    it("should have ticketNumber in input schema properties", () => {
+      const createTicketTool = ticketTools.find((t) => t.name === "create_ticket");
+      assert.ok(createTicketTool, "create_ticket tool should exist");
+
+      const properties = (createTicketTool.inputSchema as any).properties;
+      assert.ok(
+        properties.ticketNumber,
+        "ticketNumber should be in input schema properties",
+      );
+    });
+
+    it("should describe ticketNumber parameter correctly", () => {
+      const createTicketTool = ticketTools.find((t) => t.name === "create_ticket");
+      assert.ok(createTicketTool, "create_ticket tool should exist");
+
+      const ticketNumberProp = (createTicketTool.inputSchema as any).properties.ticketNumber;
+      assert.strictEqual(ticketNumberProp.type, "string");
+      assert.ok(
+        ticketNumberProp.description.includes("custom ticket number"),
+        "Description should mention custom ticket number",
+      );
+    });
+
+    it("should keep title as the only required field", () => {
+      const createTicketTool = ticketTools.find((t) => t.name === "create_ticket");
+      assert.ok(createTicketTool, "create_ticket tool should exist");
+
+      const required = (createTicketTool.inputSchema as any).required;
+      assert.deepStrictEqual(required, ["title"]);
+    });
+  });
+
+  describe("Handler Function", () => {
+    const mockContext: McpContext = {
+      projectId: "test-project",
+      ticketId: "POT-1",
+      brainstormId: "",
+      daemonUrl: "http://localhost:8443",
+    };
+
+    it("should create ticket with title only", async () => {
+      const handler = ticketHandlers.create_ticket;
+      const result = (await handler(mockContext, {
+        title: "Test Ticket",
+      })) as McpToolResult;
+
+      assert.ok(result.content);
+      assert.strictEqual(result.content[0].type, "text");
+
+      // Verify fetch was called with correct payload
+      assert.strictEqual(mockFetchCalls.length, 1);
+      const call = mockFetchCalls[0];
+      assert.strictEqual(call.method, "POST");
+      const body = JSON.parse(call.body!);
+      assert.strictEqual(body.title, "Test Ticket");
+      assert.strictEqual(body.description, "");
+      assert.ok(!body.brainstormId);
+      assert.ok(!body.ticketNumber);
+    });
+
+    it("should create ticket with title and description", async () => {
+      const handler = ticketHandlers.create_ticket;
+      const result = (await handler(mockContext, {
+        title: "Test Ticket",
+        description: "Test Description",
+      })) as McpToolResult;
+
+      assert.ok(result.content);
+
+      const call = mockFetchCalls[0];
+      const body = JSON.parse(call.body!);
+      assert.strictEqual(body.title, "Test Ticket");
+      assert.strictEqual(body.description, "Test Description");
+    });
+
+    it("should create ticket with brainstormId", async () => {
+      const handler = ticketHandlers.create_ticket;
+      const result = (await handler(mockContext, {
+        title: "Test Ticket",
+        brainstormId: "brain_123",
+      })) as McpToolResult;
+
+      assert.ok(result.content);
+
+      const call = mockFetchCalls[0];
+      const body = JSON.parse(call.body!);
+      assert.strictEqual(body.brainstormId, "brain_123");
+    });
+
+    it("should create ticket with ticketNumber", async () => {
+      const handler = ticketHandlers.create_ticket;
+      const result = (await handler(mockContext, {
+        title: "Test Ticket",
+        ticketNumber: "JIRA-42",
+      })) as McpToolResult;
+
+      assert.ok(result.content);
+
+      const call = mockFetchCalls[0];
+      const body = JSON.parse(call.body!);
+      assert.strictEqual(body.ticketNumber, "JIRA-42");
+      assert.ok(!body.brainstormId);
+    });
+
+    it("should create ticket with all parameters", async () => {
+      const handler = ticketHandlers.create_ticket;
+      const result = (await handler(mockContext, {
+        title: "Test Ticket",
+        description: "Test Description",
+        brainstormId: "brain_123",
+        ticketNumber: "JIRA-42",
+      })) as McpToolResult;
+
+      assert.ok(result.content);
+
+      const call = mockFetchCalls[0];
+      const body = JSON.parse(call.body!);
+      assert.strictEqual(body.title, "Test Ticket");
+      assert.strictEqual(body.description, "Test Description");
+      assert.strictEqual(body.brainstormId, "brain_123");
+      assert.strictEqual(body.ticketNumber, "JIRA-42");
+    });
+
+    it("should not include ticketNumber if not provided", async () => {
+      const handler = ticketHandlers.create_ticket;
+      await handler(mockContext, {
+        title: "Test Ticket",
+      });
+
+      const call = mockFetchCalls[0];
+      const body = JSON.parse(call.body!);
+      assert.ok(!("ticketNumber" in body) || body.ticketNumber === undefined);
+    });
+
+    it("should use correct API endpoint", async () => {
+      const handler = ticketHandlers.create_ticket;
+      await handler(mockContext, {
+        title: "Test Ticket",
+      });
+
+      const call = mockFetchCalls[0];
+      assert.strictEqual(
+        call.url,
+        "http://localhost:8443/api/tickets/test-project",
+      );
+    });
+
+    it("should set correct content-type header", async () => {
+      const handler = ticketHandlers.create_ticket;
+      await handler(mockContext, {
+        title: "Test Ticket",
+      });
+
+      const call = mockFetchCalls[0];
+      assert.ok(call.headers);
+      assert.strictEqual(call.headers["Content-Type"], "application/json");
+    });
+
+    it("should return formatted response on success", async () => {
+      mockFetchResponse.json = async () => ({
+        id: "JIRA-42",
+        title: "Test Ticket",
+      });
+
+      const handler = ticketHandlers.create_ticket;
+      const result = (await handler(mockContext, {
+        title: "Test Ticket",
+        ticketNumber: "JIRA-42",
+      })) as McpToolResult;
+
+      assert.ok(result.content);
+      assert.strictEqual(result.content[0].type, "text");
+      assert.ok(result.content[0].text.includes("JIRA-42"));
+      assert.ok(result.content[0].text.includes("Test Ticket"));
+    });
+
+    it("should handle error responses with error body", async () => {
+      mockFetchResponse.ok = false;
+      mockFetchResponse.statusText = "Bad Request";
+      mockFetchResponse.json = async () => ({
+        error: "Invalid ticket number format",
+      });
+
+      const handler = ticketHandlers.create_ticket;
+
+      try {
+        await handler(mockContext, {
+          title: "Test Ticket",
+          ticketNumber: "invalid!!!",
+        });
+        assert.fail("Should have thrown an error");
+      } catch (err) {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.includes("Invalid ticket number format"));
+      }
+    });
+
+    it("should handle error responses without error body", async () => {
+      mockFetchResponse.ok = false;
+      mockFetchResponse.statusText = "Internal Server Error";
+      mockFetchResponse.json = async () => {
+        throw new Error("Not JSON");
+      };
+
+      const handler = ticketHandlers.create_ticket;
+
+      try {
+        await handler(mockContext, {
+          title: "Test Ticket",
+        });
+        assert.fail("Should have thrown an error");
+      } catch (err) {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.includes("Internal Server Error"));
+      }
+    });
+  });
+});

--- a/apps/daemon/src/mcp/tools/ticket.tools.ts
+++ b/apps/daemon/src/mcp/tools/ticket.tools.ts
@@ -81,6 +81,11 @@ export const ticketTools: ToolDefinition[] = [
           type: "string",
           description: "Optional brainstorm ID this ticket originated from",
         },
+        ticketNumber: {
+          type: "string",
+          description:
+            "Optional custom ticket number (e.g. from JIRA). Replaces auto-generated ID. Only letters, numbers, hyphens, underscores allowed (max 20 chars).",
+        },
       },
       required: ["title"],
     },
@@ -242,21 +247,23 @@ async function createTicket(
   title: string,
   description?: string,
   brainstormId?: string,
+  ticketNumber?: string,
 ): Promise<unknown> {
+  const body: Record<string, string> = { title, description: description || "" };
+  if (brainstormId) body.brainstormId = brainstormId;
+  if (ticketNumber) body.ticketNumber = ticketNumber;
+
   const response = await fetch(
     `${ctx.daemonUrl}/api/tickets/${encodeURIComponent(ctx.projectId)}`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        title,
-        description: description || "",
-        brainstormId,
-      }),
+      body: JSON.stringify(body),
     },
   );
   if (!response.ok) {
-    throw new Error(`Failed to create ticket: ${response.statusText}`);
+    const errorBody = await response.json().catch(() => ({})) as { error?: string };
+    throw new Error(errorBody.error || `Failed to create ticket: ${response.statusText}`);
   }
   return await response.json();
 }
@@ -303,6 +310,7 @@ export const ticketHandlers: Record<
       args.title as string,
       args.description as string | undefined,
       args.brainstormId as string | undefined,
+      args.ticketNumber as string | undefined,
     )) as { id: string; title: string };
     return {
       content: [

--- a/apps/daemon/src/server/routes/tickets.routes.ts
+++ b/apps/daemon/src/server/routes/tickets.routes.ts
@@ -69,10 +69,11 @@ export function registerTicketRoutes(
   app.post("/api/tickets/:project", async (req: Request, res: Response) => {
     try {
       const projectId = decodeURIComponent(req.params.project);
-      const { title, description, brainstormId } = req.body as {
+      const { title, description, brainstormId, ticketNumber } = req.body as {
         title?: string;
         description?: string;
         brainstormId?: string;
+        ticketNumber?: string;
       };
 
       if (!title) {
@@ -80,7 +81,7 @@ export function registerTicketRoutes(
         return;
       }
 
-      const ticket = await createTicket(projectId, { title, description });
+      const ticket = await createTicket(projectId, { title, description, ticketNumber });
       eventBus.emit("ticket:created", { projectId, ticket });
 
       // Link brainstorm to created ticket
@@ -99,7 +100,14 @@ export function registerTicketRoutes(
 
       res.json(ticket);
     } catch (error) {
-      res.status(500).json({ error: (error as Error).message });
+      const err = error as Error & { code?: string };
+      if (err.code === "VALIDATION_ERROR") {
+        res.status(400).json({ error: err.message });
+      } else if (err.code === "CONFLICT_ERROR") {
+        res.status(409).json({ error: err.message });
+      } else {
+        res.status(500).json({ error: err.message });
+      }
     }
   });
 

--- a/apps/daemon/src/stores/__tests__/ticket.store.test.ts
+++ b/apps/daemon/src/stores/__tests__/ticket.store.test.ts
@@ -417,4 +417,149 @@ describe("TicketStore", () => {
       assert.strictEqual(current, null);
     });
   });
+
+  describe("createTicket with custom ticketNumber", () => {
+    it("should use custom ticketNumber as the ticket ID", () => {
+      const ticket = ticketStore.createTicket(projectId, {
+        title: "JIRA Import",
+        ticketNumber: "JIRA-123",
+      });
+
+      assert.strictEqual(ticket.id, "JIRA-123");
+      assert.strictEqual(ticket.title, "JIRA Import");
+      assert.strictEqual(ticket.phase, "Ideas");
+      assert.strictEqual(ticket.project, projectId);
+    });
+
+    it("should not increment auto-counter when custom ticketNumber is used", () => {
+      // Create a ticket with custom number
+      ticketStore.createTicket(projectId, {
+        title: "Custom",
+        ticketNumber: "EXT-1",
+      });
+
+      // Create a ticket with auto-generated number
+      const autoTicket = ticketStore.createTicket(projectId, {
+        title: "Auto",
+      });
+
+      // Auto ticket should be number 1, not 2 (custom didn't consume a number)
+      const num = parseInt(autoTicket.id.split("-")[1], 10);
+      assert.strictEqual(num, 1);
+    });
+
+    it("should reject ticketNumber with spaces", () => {
+      assert.throws(() => {
+        ticketStore.createTicket(projectId, {
+          title: "Bad Spaces",
+          ticketNumber: "JIRA 123",
+        });
+      }, /Invalid ticket number/);
+    });
+
+    it("should reject ticketNumber with path traversal characters", () => {
+      assert.throws(() => {
+        ticketStore.createTicket(projectId, {
+          title: "Path Traversal",
+          ticketNumber: "../etc/passwd",
+        });
+      }, /Invalid ticket number/);
+    });
+
+    it("should reject ticketNumber with slashes", () => {
+      assert.throws(() => {
+        ticketStore.createTicket(projectId, {
+          title: "Slashes",
+          ticketNumber: "JIRA/123",
+        });
+      }, /Invalid ticket number/);
+    });
+
+    it("should reject ticketNumber exceeding 20 characters", () => {
+      assert.throws(() => {
+        ticketStore.createTicket(projectId, {
+          title: "Too Long",
+          ticketNumber: "ABCDEFGHIJKLMNOPQRSTU",
+        });
+      }, /Invalid ticket number/);
+    });
+
+    it("should reject empty string ticketNumber", () => {
+      assert.throws(() => {
+        ticketStore.createTicket(projectId, {
+          title: "Empty",
+          ticketNumber: "",
+        });
+      }, /Invalid ticket number/);
+    });
+
+    it("should accept valid formats: letters, numbers, hyphens, underscores", () => {
+      const t1 = ticketStore.createTicket(projectId, {
+        title: "Hyphen",
+        ticketNumber: "JIRA-123",
+      });
+      assert.strictEqual(t1.id, "JIRA-123");
+
+      const t2 = ticketStore.createTicket(projectId, {
+        title: "Underscore",
+        ticketNumber: "ABC_456",
+      });
+      assert.strictEqual(t2.id, "ABC_456");
+
+      const t3 = ticketStore.createTicket(projectId, {
+        title: "Mixed",
+        ticketNumber: "proj-99",
+      });
+      assert.strictEqual(t3.id, "proj-99");
+    });
+
+    it("should reject duplicate custom ticketNumber", () => {
+      ticketStore.createTicket(projectId, {
+        title: "First",
+        ticketNumber: "DUP-1",
+      });
+
+      assert.throws(() => {
+        ticketStore.createTicket(projectId, {
+          title: "Second",
+          ticketNumber: "DUP-1",
+        });
+      }, /already exists/);
+    });
+
+    it("should still auto-generate when ticketNumber is undefined", () => {
+      const ticket = ticketStore.createTicket(projectId, {
+        title: "Normal Ticket",
+      });
+
+      assert.match(ticket.id, /^[A-Z]{1,3}-\d+$/);
+    });
+
+    it("should retry auto-generation when generated ID collides with a custom ticket", () => {
+      // Pre-create a ticket with a custom number that looks like an auto-generated ID
+      // The project prefix for "Test Project" is "TES"
+      ticketStore.createTicket(projectId, {
+        title: "Blocker",
+        ticketNumber: "TES-1",
+      });
+
+      // Now auto-generate — TES-1 is taken, so it should retry and get TES-2
+      const autoTicket = ticketStore.createTicket(projectId, {
+        title: "Auto After Collision",
+      });
+
+      assert.strictEqual(autoTicket.id, "TES-2");
+    });
+
+    it("should create initial history entry for custom-numbered ticket", () => {
+      const ticket = ticketStore.createTicket(projectId, {
+        title: "History Test",
+        ticketNumber: "HIST-1",
+      });
+
+      assert.strictEqual(ticket.history.length, 1);
+      assert.strictEqual(ticket.history[0].phase, "Ideas");
+      assert.ok(ticket.history[0].at);
+    });
+  });
 });

--- a/apps/daemon/src/stores/ticket.store.ts
+++ b/apps/daemon/src/stores/ticket.store.ts
@@ -99,6 +99,34 @@ export class TicketStore {
     this.conversationStore = createConversationStore(db);
   }
 
+  private static CUSTOM_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+  private validateCustomTicketNumber(ticketNumber: string): void {
+    if (ticketNumber.length === 0 || ticketNumber.length > 20) {
+      throw Object.assign(
+        new Error("Invalid ticket number: must be 1-20 characters"),
+        { code: "VALIDATION_ERROR" }
+      );
+    }
+    if (!TicketStore.CUSTOM_ID_PATTERN.test(ticketNumber)) {
+      throw Object.assign(
+        new Error(
+          "Invalid ticket number: only letters, numbers, hyphens, and underscores allowed"
+        ),
+        { code: "VALIDATION_ERROR" }
+      );
+    }
+    const existing = this.db
+      .prepare("SELECT id FROM tickets WHERE id = ?")
+      .get(ticketNumber);
+    if (existing) {
+      throw Object.assign(
+        new Error(`Ticket number '${ticketNumber}' already exists`),
+        { code: "CONFLICT_ERROR" }
+      );
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Counter Management
   // ---------------------------------------------------------------------------
@@ -126,6 +154,18 @@ export class TicketStore {
     const prefix = getProjectPrefixFromDb(this.db, projectId);
     const number = this.getNextTicketNumber(projectId);
     return `${prefix}-${number}`;
+  }
+
+  private generateTicketIdWithRetry(projectId: string): string {
+    const maxAttempts = 5;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const id = this.generateTicketId(projectId);
+      const exists = this.db
+        .prepare("SELECT 1 FROM tickets WHERE id = ?")
+        .get(id);
+      if (!exists) return id;
+    }
+    throw new Error("Failed to generate unique ticket ID after 5 attempts");
   }
 
   // ---------------------------------------------------------------------------
@@ -183,7 +223,13 @@ export class TicketStore {
   }
 
   createTicket(projectId: string, input: CreateTicketInput): Ticket {
-    const id = this.generateTicketId(projectId);
+    let id: string;
+    if (input.ticketNumber !== undefined) {
+      this.validateCustomTicketNumber(input.ticketNumber);
+      id = input.ticketNumber;
+    } else {
+      id = this.generateTicketIdWithRetry(projectId);
+    }
     const now = new Date().toISOString();
     const initialPhase = "Ideas";
     const description = input.description || "";

--- a/apps/daemon/src/types/ticket.types.ts
+++ b/apps/daemon/src/types/ticket.types.ts
@@ -21,6 +21,7 @@ export type TicketPhase = string;
 export interface CreateTicketInput {
   title: string;
   description?: string;
+  ticketNumber?: string;
 }
 
 export interface UpdateTicketInput {

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -107,10 +107,14 @@ export const api = {
   getTicket: (projectId: string, ticketId: string) =>
     request<Ticket>(`/api/tickets/${encodeURIComponent(projectId)}/${ticketId}`),
 
-  createTicket: (projectId: string, title: string, description?: string) =>
+  createTicket: (projectId: string, title: string, description?: string, ticketNumber?: string) =>
     request<Ticket>(`/api/tickets/${encodeURIComponent(projectId)}`, {
       method: 'POST',
-      body: JSON.stringify({ title, description })
+      body: JSON.stringify({
+        title,
+        description,
+        ...(ticketNumber ? { ticketNumber } : {}),
+      })
     }),
 
   updateTicket: (projectId: string, ticketId: string, updates: Partial<Ticket> & { force?: boolean }) =>

--- a/apps/frontend/src/components/board/AddTicketModal.test.tsx
+++ b/apps/frontend/src/components/board/AddTicketModal.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AddTicketModal } from './AddTicketModal'
 
@@ -48,6 +48,10 @@ describe('AddTicketModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockCreateTicket.mockResolvedValue({ id: 'TEST-1', title: 'Test' })
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('renders the title input with autoComplete="off"', () => {

--- a/apps/frontend/src/components/board/AddTicketModal.test.tsx
+++ b/apps/frontend/src/components/board/AddTicketModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AddTicketModal } from './AddTicketModal'
 

--- a/apps/frontend/src/components/board/AddTicketModal.test.tsx
+++ b/apps/frontend/src/components/board/AddTicketModal.test.tsx
@@ -1,11 +1,16 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { AddTicketModal } from './AddTicketModal'
 
 // Mock external dependencies
+const mockCreateTicket = vi.fn()
+const mockInvalidateQueries = vi.fn()
+const mockCloseModal = vi.fn()
+
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({
-    invalidateQueries: vi.fn(),
+    invalidateQueries: mockInvalidateQueries,
   }),
 }))
 
@@ -14,13 +19,13 @@ vi.mock('@/stores/appStore', () => ({
     selector({
       currentProjectId: 'test-project',
       addTicketModalOpen: true,
-      closeAddTicketModal: vi.fn(),
+      closeAddTicketModal: mockCloseModal,
     }),
 }))
 
 vi.mock('@/api/client', () => ({
   api: {
-    createTicket: vi.fn(),
+    createTicket: (...args: unknown[]) => mockCreateTicket(...args),
   },
 }))
 
@@ -40,10 +45,72 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 describe('AddTicketModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateTicket.mockResolvedValue({ id: 'TEST-1', title: 'Test' })
+  })
+
   it('renders the title input with autoComplete="off"', () => {
     render(<AddTicketModal />)
-
     const titleInput = screen.getByPlaceholderText('Ticket title') as HTMLInputElement
     expect(titleInput.getAttribute('autocomplete')).toBe('off')
+  })
+
+  it('renders the ticket number field', () => {
+    render(<AddTicketModal />)
+    const ticketNumberInput = screen.getByPlaceholderText('e.g. JIRA-123 (optional)')
+    expect(ticketNumberInput).toBeTruthy()
+  })
+
+  it('submits with custom ticket number', async () => {
+    const user = userEvent.setup()
+    render(<AddTicketModal />)
+
+    const titleInput = screen.getByPlaceholderText('Ticket title')
+    const ticketNumberInput = screen.getByPlaceholderText('e.g. JIRA-123 (optional)')
+    const submitButton = screen.getByText('Create Ticket')
+
+    await user.type(titleInput, 'My Ticket')
+    await user.type(ticketNumberInput, 'JIRA-456')
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockCreateTicket).toHaveBeenCalledWith('test-project', 'My Ticket', undefined, 'JIRA-456')
+    })
+  })
+
+  it('submits without ticket number when field is empty', async () => {
+    const user = userEvent.setup()
+    render(<AddTicketModal />)
+
+    const titleInput = screen.getByPlaceholderText('Ticket title')
+    const submitButton = screen.getByText('Create Ticket')
+
+    await user.type(titleInput, 'Normal Ticket')
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockCreateTicket).toHaveBeenCalledWith('test-project', 'Normal Ticket', undefined, undefined)
+    })
+  })
+
+  it('shows validation error for invalid characters in ticket number', async () => {
+    const user = userEvent.setup()
+    render(<AddTicketModal />)
+
+    const ticketNumberInput = screen.getByPlaceholderText('e.g. JIRA-123 (optional)')
+    await user.type(ticketNumberInput, 'JIRA 123')
+
+    expect(screen.getByText(/only letters, numbers, hyphens, and underscores/i)).toBeTruthy()
+  })
+
+  it('shows validation error when ticket number exceeds 20 characters', async () => {
+    const user = userEvent.setup()
+    render(<AddTicketModal />)
+
+    const ticketNumberInput = screen.getByPlaceholderText('e.g. JIRA-123 (optional)')
+    await user.type(ticketNumberInput, 'ABCDEFGHIJKLMNOPQRSTU')
+
+    expect(screen.getByText(/max 20 characters/i)).toBeTruthy()
   })
 })

--- a/apps/frontend/src/components/board/AddTicketModal.tsx
+++ b/apps/frontend/src/components/board/AddTicketModal.tsx
@@ -25,10 +25,29 @@ export function AddTicketModal() {
   const [description, setDescription] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [ticketNumber, setTicketNumber] = useState('')
+  const [ticketNumberError, setTicketNumberError] = useState<string | null>(null)
+
+  const CUSTOM_ID_PATTERN = /^[a-zA-Z0-9_-]*$/
+
+  const handleTicketNumberChange = useCallback((value: string) => {
+    setTicketNumber(value)
+    if (value === '') {
+      setTicketNumberError(null)
+    } else if (!CUSTOM_ID_PATTERN.test(value)) {
+      setTicketNumberError('Only letters, numbers, hyphens, and underscores allowed')
+    } else if (value.length > 20) {
+      setTicketNumberError('Max 20 characters')
+    } else {
+      setTicketNumberError(null)
+    }
+  }, [])
 
   const resetForm = useCallback(() => {
     setTitle('')
     setDescription('')
+    setTicketNumber('')
+    setTicketNumberError(null)
     setError(null)
   }, [])
 
@@ -38,13 +57,19 @@ export function AddTicketModal() {
   }, [closeModal, resetForm])
 
   const handleSubmit = useCallback(async () => {
-    if (!currentProjectId || !title.trim()) return
+    if (!currentProjectId || !title.trim() || ticketNumberError) return
 
     setIsSubmitting(true)
     setError(null)
 
     try {
-      await api.createTicket(currentProjectId, title.trim(), description.trim() || undefined)
+      const trimmedTicketNumber = ticketNumber.trim()
+      await api.createTicket(
+        currentProjectId,
+        title.trim(),
+        description.trim() || undefined,
+        trimmedTicketNumber || undefined,
+      )
       queryClient.invalidateQueries({ queryKey: ['tickets', currentProjectId] })
       handleClose()
     } catch (err) {
@@ -52,7 +77,7 @@ export function AddTicketModal() {
     } finally {
       setIsSubmitting(false)
     }
-  }, [currentProjectId, title, description, queryClient, handleClose])
+  }, [currentProjectId, title, description, ticketNumber, ticketNumberError, queryClient, handleClose])
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && title.trim() && !isSubmitting) {
@@ -90,6 +115,25 @@ export function AddTicketModal() {
           </div>
 
           <div className="space-y-2">
+            <label htmlFor="ticket-number" className="text-sm text-text-secondary">
+              Ticket Number <span className="text-text-muted">(optional)</span>
+            </label>
+            <Input
+              id="ticket-number"
+              value={ticketNumber}
+              onChange={(e) => handleTicketNumberChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g. JIRA-123 (optional)"
+              disabled={isSubmitting}
+              autoComplete="off"
+              className="bg-bg-tertiary border-border"
+            />
+            {ticketNumberError && (
+              <p className="text-sm text-accent-red">{ticketNumberError}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
             <label htmlFor="ticket-description" className="text-sm text-text-secondary">
               Description <span className="text-text-muted">(optional)</span>
             </label>
@@ -112,7 +156,7 @@ export function AddTicketModal() {
           <Button variant="outline" onClick={handleClose} disabled={isSubmitting}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={!title.trim() || isSubmitting}>
+          <Button onClick={handleSubmit} disabled={!title.trim() || isSubmitting || !!ticketNumberError}>
             {isSubmitting ? (
               <>
                 <Loader2 className="h-4 w-4 mr-1 animate-spin" />

--- a/apps/frontend/src/components/board/BrainstormCard.tsx
+++ b/apps/frontend/src/components/board/BrainstormCard.tsx
@@ -70,17 +70,15 @@ export function BrainstormCard({ brainstorm, projectId }: BrainstormCardProps) {
           <Clock className="h-3 w-3" />
           {timeAgo(brainstorm.updatedAt)}
         </span>
-        <StatusIndicator status={brainstorm.status} hasUnseenQuestion={hasUnseenQuestion} />
+        <StatusIndicator hasUnseenQuestion={hasUnseenQuestion} />
       </div>
     </button>
   )
 }
 
 function StatusIndicator({
-  status,
   hasUnseenQuestion
 }: {
-  status: Brainstorm['status']
   hasUnseenQuestion: boolean
 }) {
   if (hasUnseenQuestion) {

--- a/apps/frontend/src/components/brainstorm/BrainstormListItem.tsx
+++ b/apps/frontend/src/components/brainstorm/BrainstormListItem.tsx
@@ -71,7 +71,6 @@ export function BrainstormListItem({
               {brainstorm.name}
             </span>
             <StatusIndicator
-              status={brainstorm.status}
               hasUnseenQuestion={hasUnseenQuestion}
             />
           </div>
@@ -86,10 +85,8 @@ export function BrainstormListItem({
 }
 
 function StatusIndicator({
-  status,
   hasUnseenQuestion
 }: {
-  status: Brainstorm['status']
   hasUnseenQuestion: boolean
 }) {
   // Active brainstorm with unseen pending question - show unread indicator


### PR DESCRIPTION
## Summary

Adds the ability to set a custom ticket number when creating tickets, enabling users to preserve ticket IDs from external systems like JIRA. The ticket number is an optional field — when provided, it replaces the auto-generated ID; when omitted, existing auto-increment behavior continues unchanged.

## Changes

- `apps/daemon/src/types/ticket.types.ts` — Added optional `ticketNumber` to `CreateTicketInput`
- `apps/daemon/src/stores/ticket.store.ts` — Custom ID validation (alphanumeric + hyphens/underscores, max 20 chars), duplicate checking, and auto-generation retry loop for collision handling
- `apps/daemon/src/server/routes/tickets.routes.ts` — Accept `ticketNumber` in POST body with 400/409 error responses
- `apps/daemon/src/mcp/tools/ticket.tools.ts` — Added `ticketNumber` parameter to MCP `create_ticket` tool
- `apps/frontend/src/api/client.ts` — Extended `createTicket` with optional `ticketNumber` param
- `apps/frontend/src/components/board/AddTicketModal.tsx` — New optional "Ticket Number" field with client-side validation
- `apps/daemon/src/stores/__tests__/ticket.store.test.ts` — 11 new tests for custom ticket number store logic
- `apps/daemon/src/mcp/tools/__tests__/ticket.tools.test.ts` — New MCP tool tests
- `apps/frontend/src/components/board/AddTicketModal.test.tsx` — 6 tests for the modal field

## Testing

- All daemon tests passing (536 tests, 0 failures)
- All frontend tests passing (119 tests, 16 test files)
- Path traversal prevention validated via strict character allowlist `[a-zA-Z0-9_-]`

## Documentation

- [Refinement](refinement.md) — Requirements, scope, and key decisions
- [Architecture](architecture.md) — Technical design across 6 files in 3 layers
- [Specification](specification.md) — Implementation plan with 9 tickets and TDD steps

---
🥔 Baked with [Potato Cannon](https://github.com/crathgeb/potato-cannon)