### PR TITLE
Fix frontend build: remove unused status parameter

### DIFF
--- a/apps/frontend/src/components/board/BrainstormCard.tsx
+++ b/apps/frontend/src/components/board/BrainstormCard.tsx
@@ -70,17 +70,15 @@ export function BrainstormCard({ brainstorm, projectId }: BrainstormCardProps) {
           <Clock className="h-3 w-3" />
           {timeAgo(brainstorm.updatedAt)}
         </span>
-        <StatusIndicator status={brainstorm.status} hasUnseenQuestion={hasUnseenQuestion} />
+        <StatusIndicator hasUnseenQuestion={hasUnseenQuestion} />
       </div>
     </button>
   )
 }
 
 function StatusIndicator({
-  status,
   hasUnseenQuestion
 }: {
-  status: Brainstorm['status']
   hasUnseenQuestion: boolean
 }) {
   if (hasUnseenQuestion) {

--- a/apps/frontend/src/components/brainstorm/BrainstormListItem.tsx
+++ b/apps/frontend/src/components/brainstorm/BrainstormListItem.tsx
@@ -71,7 +71,6 @@ export function BrainstormListItem({
               {brainstorm.name}
             </span>
             <StatusIndicator
-              status={brainstorm.status}
               hasUnseenQuestion={hasUnseenQuestion}
             />
           </div>
@@ -86,10 +85,8 @@ export function BrainstormListItem({
 }
 
 function StatusIndicator({
-  status,
   hasUnseenQuestion
 }: {
-  status: Brainstorm['status']
   hasUnseenQuestion: boolean
 }) {
   // Active brainstorm with unseen pending question - show unread indicator


### PR DESCRIPTION
## Summary
- Removes unused `status` prop from `StatusIndicator` in `BrainstormCard` and `BrainstormListItem`
- Fixes TS6133 errors that break `pnpm build`

## Test plan
- [x] `pnpm build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)