### PR TITLE
fix: disable chat UI even when answer was given (i.e. Pull Requests)

### DIFF
--- a/apps/daemon/src/server/routes/tickets.routes.ts
+++ b/apps/daemon/src/server/routes/tickets.routes.ts
@@ -21,7 +21,7 @@ import {
   appendConversation,
 } from "../../stores/ticket.store.js";
 import { DEFAULT_PHASES } from "../../types/index.js";
-import { readQuestion, writeResponse } from "../../stores/chat.store.js";
+import { readQuestion, writeResponse, clearQuestion } from "../../stores/chat.store.js";
 import { getActiveSessionForTicket } from "../../stores/session.store.js";
 import { getMessages } from "../../stores/conversation.store.js";
 import { updateBrainstorm } from "../../stores/brainstorm.store.js";
@@ -528,7 +528,8 @@ export function registerTicketRoutes(
               return;
             } catch (err) {
               console.error(`[input] Failed to resume suspended ticket: ${(err as Error).message}`);
-              // Fall through — response is already written, blocking session may pick it up
+              // Clean up the stale pending question so the UI doesn't stay enabled
+              clearQuestion(projectId, ticketId);
             }
           }
         }

--- a/apps/daemon/src/stores/chat.store.ts
+++ b/apps/daemon/src/stores/chat.store.ts
@@ -271,7 +271,7 @@ export function getPendingQuestionsByProject(): Map<string, string[]> {
   const rows = db.prepare(`
     SELECT project_id, context_id
     FROM pending_questions
-    WHERE context_type = 'ticket'
+    WHERE context_type = 'ticket' AND answer IS NULL
   `).all() as Array<{ project_id: string; context_id: string }>;
 
   const result = new Map<string, string[]>();

--- a/apps/frontend/src/components/ticket-detail/ActivityTab.tsx
+++ b/apps/frontend/src/components/ticket-detail/ActivityTab.tsx
@@ -333,9 +333,11 @@ export function ActivityTab({ projectId, ticketId, currentPhase: propPhase, hist
               )}
             </Button>
           </div>
-          <p className="text-xs text-text-muted mt-2 px-4">
-            Press Enter to send, Shift+Enter for new line
-          </p>
+          {isAgentActive && (
+            <p className="text-xs text-text-muted mt-2 px-4">
+              Press Enter to send, Shift+Enter for new line
+            </p>
+          )}
         </div>
       </div>
 

--- a/apps/frontend/src/components/ticket-detail/ArtifactChat.tsx
+++ b/apps/frontend/src/components/ticket-detail/ArtifactChat.tsx
@@ -325,9 +325,11 @@ export function ArtifactChat({
             )}
           </Button>
         </div>
-        <p className="text-xs text-text-muted mt-2">
-          Press Enter to send, Shift+Enter for new line
-        </p>
+        {sessionActive && (
+          <p className="text-xs text-text-muted mt-2">
+            Press Enter to send, Shift+Enter for new line
+          </p>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
Handles a corner case where no agent is running yet one is defined and has finished doing its job, i.e. it's not prepared to talk to you anymore.

This isn't an unqualified usability improvement; see below for the trade offs.

An alternative idea would be to _undo_ our work to prevent chat in these phases, and instead create some sort of lightweight agent/session which only has access to some MCP tools for managing that specific ticket (i.e. moving back/forward upon request and after consideration).

OTOH, there's a KISS argument to just keep the user from trying to converse when nobody would answer, and relying on the agent to _do_ the phases and not to drag and drop the ticket between phases (that's what the human is for).

So maybe this is a good change. Should either pair it with existing main change, or back out existing main change.

# Upside: no false conversation tease in a phase like Pull Request

Unqualified win; chatting in this phase can't do anything.

<img width="482" height="864" alt="image" src="https://github.com/user-attachments/assets/f74333f6-dcdc-4091-a1d7-8c46fcca17c5" />

# Downside: hostile non-conversation in a phase like Ideas

Morally, I'd hope that I _would_ be able to chat with an agent about my ideas; then again, there's nothing the agent in this lane can _do_ for the ideas which is why we don't run a session for ticket in this lane. So maybe disabling chat is what we want here.

<img width="479" height="863" alt="image" src="https://github.com/user-attachments/assets/08825d94-83fd-4837-b32c-5f83d1b17cb4" />
