### PR TITLE
fix: visual artifact w/ brainstorm panel reserved space

### DIFF
--- a/apps/frontend/src/components/brainstorm/BrainstormDetailPanel.test.tsx
+++ b/apps/frontend/src/components/brainstorm/BrainstormDetailPanel.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { BrainstormDetailPanel } from './BrainstormDetailPanel'
+
+const mockInvalidateQueries = vi.fn()
+
+let mockPathname = '/projects/project-1/board'
+
+const mockState = {
+  brainstormSheetOpen: true,
+  brainstormSheetBrainstormId: 'brainstorm-1',
+  brainstormSheetProjectId: 'project-1',
+  brainstormSheetBrainstormName: 'Test Brainstorm',
+  brainstormSheetIsCreating: false,
+  closeBrainstormSheet: vi.fn(),
+  openBrainstormSheet: vi.fn(),
+  currentProjectId: 'project-1',
+}
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({ pathname: mockPathname }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}))
+
+vi.mock('@/api/client', () => ({
+  api: {
+    createBrainstorm: vi.fn(),
+  },
+}))
+
+vi.mock('@/stores/appStore', () => ({
+  useAppStore: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+}))
+
+vi.mock('./BrainstormChat', () => ({
+  BrainstormChat: () => <div>Brainstorm Chat</div>,
+}))
+
+vi.mock('./BrainstormNewForm', () => ({
+  BrainstormNewForm: () => <div>Brainstorm New Form</div>,
+}))
+
+describe('BrainstormDetailPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPathname = '/projects/project-1/board'
+  })
+
+  it('uses the outer panel width instead of a second fixed width wrapper', () => {
+    const { container } = render(<BrainstormDetailPanel />)
+
+    const panel = container.firstElementChild
+    const innerWrapper = panel?.firstElementChild
+
+    expect(panel?.className).toContain('brainstorm-detail-panel')
+    expect(innerWrapper?.className).toContain('w-full')
+    expect(innerWrapper?.className).toContain('max-w-full')
+    expect(innerWrapper?.className).not.toContain('w-[600px]')
+    expect(innerWrapper?.className).not.toContain('max-w-[40vw]')
+  })
+})

--- a/apps/frontend/src/components/brainstorm/BrainstormDetailPanel.tsx
+++ b/apps/frontend/src/components/brainstorm/BrainstormDetailPanel.tsx
@@ -99,7 +99,7 @@ export function BrainstormDetailPanel() {
       className="brainstorm-detail-panel"
       data-open={isOpen}
     >
-      <div className="flex flex-col h-full w-[600px] max-w-[40vw]">
+      <div className="flex flex-col h-full w-full max-w-full">
         {/* Header */}
         <div className="flex items-center justify-between p-4 pb-0">
           <div className="flex items-center gap-2 min-w-0 flex-1">


### PR DESCRIPTION
This pull request adds a new test file for the `BrainstormDetailPanel` component and updates the component's layout to improve its responsiveness. The main focus is to ensure the panel uses the full available width instead of a fixed width, and to provide test coverage for this behavior.

**Testing improvements:**

* Added a new test file `BrainstormDetailPanel.test.tsx` with a test to verify that the panel uses the full width (`w-full max-w-full`) instead of a fixed width, and does not include the old fixed width classes (`w-[600px]`, `max-w-[40vw]`). Mocks were added for external dependencies and store usage.

**Component layout update:**

* Updated the `BrainstormDetailPanel` component to replace the fixed width classes (`w-[600px] max-w-[40vw]`) with responsive classes (`w-full max-w-full`) for better layout flexibility.