### PR TITLE
Fix: session crash due to pty buffering oddities during JSONL parsing

### DIFF
--- a/apps/daemon/src/services/session/session.service.ts
+++ b/apps/daemon/src/services/session/session.service.ts
@@ -433,11 +433,23 @@ export class SessionService {
     // original session ID. The stored session already has the correct one.
     let claudeSessionIdCaptured = !!claudeResumeSessionId;
 
+    // Buffer for partial lines from PTY — the system init event is often
+    // larger than a single PTY chunk, so data arrives split across multiple
+    // onData calls.  We accumulate until we see a newline delimiter.
+    let ptyBuffer = "";
+
     proc.onData((data: string) => {
-      const lines = data.split("\n").filter(Boolean);
-      for (const line of lines) {
+      ptyBuffer += data;
+      const parts = ptyBuffer.split("\n");
+      // Last element is either empty (if data ended with \n) or an
+      // incomplete line — keep it in the buffer for the next onData call.
+      ptyBuffer = parts.pop() || "";
+
+      for (const line of parts) {
+        const trimmed = line.trimEnd();  // strip trailing \r from PTY
+        if (!trimmed) continue;
         try {
-          const event = JSON.parse(line);
+          const event = JSON.parse(trimmed);
           const logEntry = { ...event, timestamp: new Date().toISOString() };
           logStream.write(JSON.stringify(logEntry) + "\n");
           this.eventEmitter.emit("session:output", {
@@ -458,7 +470,7 @@ export class SessionService {
         } catch {
           const logEntry = {
             type: "raw",
-            content: line,
+            content: trimmed,
             timestamp: new Date().toISOString(),
           };
           logStream.write(JSON.stringify(logEntry) + "\n");
@@ -467,6 +479,23 @@ export class SessionService {
     });
 
     proc.onExit(({ exitCode }) => {
+      // Flush any remaining PTY buffer content
+      if (ptyBuffer.trim()) {
+        const trimmed = ptyBuffer.trimEnd();
+        try {
+          const event = JSON.parse(trimmed);
+          const logEntry = { ...event, timestamp: new Date().toISOString() };
+          logStream.write(JSON.stringify(logEntry) + "\n");
+          if (!claudeSessionIdCaptured && event.type === "system" && event.session_id) {
+            claudeSessionIdCaptured = true;
+            updateClaudeSessionId(sessionId, event.session_id);
+          }
+        } catch {
+          logStream.write(JSON.stringify({ type: "raw", content: trimmed, timestamp: new Date().toISOString() }) + "\n");
+        }
+        ptyBuffer = "";
+      }
+
       console.log(
         `[spawnClaudeSession] Agent ${agentType} exited with code: ${exitCode}`,
       );


### PR DESCRIPTION
This pull request improves how PTY (pseudo-terminal) output is handled in the `SessionService` to ensure that log events are correctly processed even when data arrives in partial lines. The changes introduce a buffer for PTY data, accumulate partial lines until a newline is received, and ensure any remaining data is flushed when the process exits. This helps prevent loss or corruption of log events, especially when lines are split across multiple data chunks.

**PTY output handling improvements:**

* Added a `ptyBuffer` to accumulate incoming PTY data and process complete lines only when a newline delimiter is encountered, ensuring partial lines are not prematurely parsed or lost. (`apps/daemon/src/services/session/session.service.ts` [apps/daemon/src/services/session/session.service.tsR436-R452](diffhunk://#diff-d60204dabae33ef3723ccdd3323516604800fb04d1aabafd113a8952107f4ebdR436-R452))
* Updated the data processing logic to trim trailing carriage returns from each line before parsing, and to use the trimmed content in both successful and fallback (raw) log entries. (`apps/daemon/src/services/session/session.service.ts` [[1]](diffhunk://#diff-d60204dabae33ef3723ccdd3323516604800fb04d1aabafd113a8952107f4ebdR436-R452) [[2]](diffhunk://#diff-d60204dabae33ef3723ccdd3323516604800fb04d1aabafd113a8952107f4ebdL461-R473)
* On process exit, flush any remaining content in the `ptyBuffer` as either a structured event or a raw log entry, ensuring all output is captured even if the last chunk did not end with a newline. (`apps/daemon/src/services/session/session.service.ts` [apps/daemon/src/services/session/session.service.tsR482-R498](diffhunk://#diff-d60204dabae33ef3723ccdd3323516604800fb04d1aabafd113a8952107f4ebdR482-R498))